### PR TITLE
fix: INTMDB-1155 Atlas Basic L3 ip access list made mandatory 

### DIFF
--- a/API.md
+++ b/API.md
@@ -26789,9 +26789,9 @@ const atlasBasicProps: AtlasBasicProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#awscdk-resources-mongodbatlas.AtlasBasicProps.property.clusterProps">clusterProps</a></code> | <code><a href="#awscdk-resources-mongodbatlas.ClusterProps">ClusterProps</a></code> | *No description.* |
+| <code><a href="#awscdk-resources-mongodbatlas.AtlasBasicProps.property.ipAccessListProps">ipAccessListProps</a></code> | <code><a href="#awscdk-resources-mongodbatlas.IpAccessListProps">IpAccessListProps</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.AtlasBasicProps.property.projectProps">projectProps</a></code> | <code><a href="#awscdk-resources-mongodbatlas.ProjectProps">ProjectProps</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.AtlasBasicProps.property.dbUserProps">dbUserProps</a></code> | <code><a href="#awscdk-resources-mongodbatlas.DatabaseUserProps">DatabaseUserProps</a></code> | *No description.* |
-| <code><a href="#awscdk-resources-mongodbatlas.AtlasBasicProps.property.ipAccessListProps">ipAccessListProps</a></code> | <code><a href="#awscdk-resources-mongodbatlas.IpAccessListProps">IpAccessListProps</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.AtlasBasicProps.property.profile">profile</a></code> | <code>string</code> | *No description.* |
 
 ---
@@ -26803,6 +26803,16 @@ public readonly clusterProps: ClusterProps;
 ```
 
 - *Type:* <a href="#awscdk-resources-mongodbatlas.ClusterProps">ClusterProps</a>
+
+---
+
+##### `ipAccessListProps`<sup>Required</sup> <a name="ipAccessListProps" id="awscdk-resources-mongodbatlas.AtlasBasicProps.property.ipAccessListProps"></a>
+
+```typescript
+public readonly ipAccessListProps: IpAccessListProps;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.IpAccessListProps">IpAccessListProps</a>
 
 ---
 
@@ -26823,16 +26833,6 @@ public readonly dbUserProps: DatabaseUserProps;
 ```
 
 - *Type:* <a href="#awscdk-resources-mongodbatlas.DatabaseUserProps">DatabaseUserProps</a>
-
----
-
-##### `ipAccessListProps`<sup>Optional</sup> <a name="ipAccessListProps" id="awscdk-resources-mongodbatlas.AtlasBasicProps.property.ipAccessListProps"></a>
-
-```typescript
-public readonly ipAccessListProps: IpAccessListProps;
-```
-
-- *Type:* <a href="#awscdk-resources-mongodbatlas.IpAccessListProps">IpAccessListProps</a>
 
 ---
 

--- a/src/l3-resources/atlas-basic/index.ts
+++ b/src/l3-resources/atlas-basic/index.ts
@@ -114,7 +114,6 @@ export class AtlasBasic extends Construct {
       {
         profile: props.profile,
         projectId: this.mProject.attrId,
-        accessList: props.ipAccessListProps?.accessList,
         ...props.ipAccessListProps,
       }
     );

--- a/src/l3-resources/common/props.ts
+++ b/src/l3-resources/common/props.ts
@@ -40,7 +40,7 @@ export interface AtlasBasicProps {
    * @type {IpAccessListProps}
    * @memberof AtlasBasicProps
    */
-  readonly ipAccessListProps?: IpAccessListProps;
+  readonly ipAccessListProps: IpAccessListProps;
 }
 
 export interface AtlasServerlessBasicProps {

--- a/test/l3-resources/atlas-basic/index.test.ts
+++ b/test/l3-resources/atlas-basic/index.test.ts
@@ -19,6 +19,8 @@ import * as l3 from "../../../src";
 const RESOURCE_NAME_PROJECT = "MongoDB::Atlas::Project";
 const RESOURCE_NAME_CLUSTER = "MongoDB::Atlas::Cluster";
 const RESOURCE_NAME_DB_USER = "MongoDB::Atlas::DatabaseUser";
+const RESOURCE_NAME_PROJECT_IP_ACCESS_LIST =
+  "MongoDB::Atlas::ProjectIpAccessList";
 const PROJECT_ID = "testProjectId";
 const ORG_ID = "testProjectId";
 const PROJECT_NAME = "test";
@@ -29,6 +31,7 @@ const DATABASE_USER_NAME = "atlas-user";
 const ADMIN_DB = "admin";
 const ROLE_NAME = "atlasAdmin";
 const PWD = "test";
+const IP_ACCESS = "0000";
 
 test("AtlasBasis construct should contain default properties", () => {
   const mockApp = new App();
@@ -60,6 +63,9 @@ test("AtlasBasis construct should contain default properties", () => {
       projectId: PROJECT_ID,
       databaseName: DATABASE_NAME,
       password: PWD,
+    },
+    ipAccessListProps: {
+      accessList: [{ ipAddress: IP_ACCESS, comment: "My first IP address" }],
     },
   });
 
@@ -100,5 +106,9 @@ test("AtlasBasis construct should contain default properties", () => {
         RoleName: ROLE_NAME,
       },
     ],
+  });
+
+  template.hasResourceProperties(RESOURCE_NAME_PROJECT_IP_ACCESS_LIST, {
+    AccessList: [{ IPAddress: IP_ACCESS, Comment: "My first IP address" }],
   });
 });


### PR DESCRIPTION
## Proposed changes
In the Atlas Basic L3 construction, the IPAccessList properties were initially marked as optional, causing user confusion by suggesting they were not necessary. 

After thorough analysis in collaboration with @Zuhairahmed, we've determined that the API access list is a crucial requirement for project accessibility. As the IPAccess lists are integral components of the L3 Atlas Basic pattern, we have updated our approach to make them mandatory.

_Jira ticket:_ [INTMDB-1155(https://jira.mongodb.org/browse/INTMDB-1155)


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)

## Further comments
