### PR TITLE
fix: backups were always enabled in L3 construct "AtlasEncryptionAtRestExpress"

### DIFF
--- a/src/l3-resources/encryption-at-rest-express/index.ts
+++ b/src/l3-resources/encryption-at-rest-express/index.ts
@@ -54,7 +54,7 @@ function getClusterProps(
       inputClusterProps.name || "atlas-cluster-".concat(String(randomNumber())),
     mongoDbMajorVersion:
       inputClusterProps.mongoDbMajorVersion || MONGODB_VERSION,
-    backupEnabled: inputClusterProps.backupEnabled || BACKUP_ENABLED,
+    backupEnabled: inputClusterProps.backupEnabled ?? BACKUP_ENABLED,
     diskSizeGb: inputClusterProps.diskSizeGb,
     clusterType: inputClusterProps.clusterType || CLUSTER_TYPE,
     biConnector: inputClusterProps.biConnector,

--- a/test/l3-resources/encryption-at-rest-express/index.test.ts
+++ b/test/l3-resources/encryption-at-rest-express/index.test.ts
@@ -18,6 +18,7 @@ import * as l3 from "../../../src";
 
 const PROJECT_ID = "PROJ_ID";
 const PROJECT_NAME = "TEST";
+const BACKUP_ENABLED = false;
 const ROLE_ID = "ROLE_ID";
 const CUSTOMER_MASTER_KEY = "MASTER_KEY";
 const DATABASE_NAME = "DATABASE_NAME";
@@ -41,6 +42,7 @@ test("Encryption at rest express construct should contain default properties", (
   new l3.AtlasEncryptionAtRestExpress(stack, "testing-stack", {
     cluster: {
       name: PROJECT_NAME,
+      backupEnabled: BACKUP_ENABLED,
     },
 
     accessList: {
@@ -70,6 +72,7 @@ test("Encryption at rest express construct should contain default properties", (
   template.hasResourceProperties(RESOURCE_NAME_CLUSTER, {
     ClusterType: "REPLICASET",
     Name: PROJECT_NAME,
+    BackupEnabled: BACKUP_ENABLED,
     ReplicationSpecs: [
       {
         NumShards: 1,


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas AWS CDK Resources!
Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/awscdk-resources-mongodbatlas/blob/master/CONTRIBUTING.md
Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Currently it is not possible to disable cluster backups when using the L3 construct `AtlasEncryptionAtRestExpress`. This happened due to `||` being used as fallback operator with a default value of `true`, which always evaluates to `true` regardless of the cluster props provided by the user.

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)

## Further comments
