### PR TITLE
fix: Fixes trigger attributes name and type that are required but were as optional

### DIFF
--- a/API.md
+++ b/API.md
@@ -35452,17 +35452,17 @@ const cfnTriggerProps: CfnTriggerProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.appId">appId</a></code> | <code>string</code> | App Services Application ID. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.name">name</a></code> | <code>string</code> | The trigger's name. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.projectId">projectId</a></code> | <code>string</code> | Project Id for application services. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.type">type</a></code> | <code>string</code> | The trigger's type. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.authTrigger">authTrigger</a></code> | <code><a href="#awscdk-resources-mongodbatlas.AuthConfig">AuthConfig</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.databaseTrigger">databaseTrigger</a></code> | <code><a href="#awscdk-resources-mongodbatlas.DatabaseConfig">DatabaseConfig</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.disabled">disabled</a></code> | <code>boolean</code> | If `true`, the trigger is disabled and does not listen for events or execute. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.eventProcessors">eventProcessors</a></code> | <code><a href="#awscdk-resources-mongodbatlas.Event">Event</a></code> | An object where each field name is an event processor ID and each value is an object that configures its corresponding event processor. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.functionId">functionId</a></code> | <code>string</code> | The ID of the function that the trigger calls when it fires. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.functionName">functionName</a></code> | <code>string</code> | The name of the function that the trigger calls when it fires, i.e. the function described by `function_id`. |
-| <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.name">name</a></code> | <code>string</code> | The trigger's name. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.profile">profile</a></code> | <code>string</code> | The profile is defined in AWS Secret manager. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.scheduleTrigger">scheduleTrigger</a></code> | <code><a href="#awscdk-resources-mongodbatlas.ScheduleConfig">ScheduleConfig</a></code> | *No description.* |
-| <code><a href="#awscdk-resources-mongodbatlas.CfnTriggerProps.property.type">type</a></code> | <code>string</code> | The trigger's type. |
 
 ---
 
@@ -35478,6 +35478,18 @@ App Services Application ID.
 
 ---
 
+##### `name`<sup>Required</sup> <a name="name" id="awscdk-resources-mongodbatlas.CfnTriggerProps.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The trigger's name.
+
+---
+
 ##### `projectId`<sup>Required</sup> <a name="projectId" id="awscdk-resources-mongodbatlas.CfnTriggerProps.property.projectId"></a>
 
 ```typescript
@@ -35487,6 +35499,18 @@ public readonly projectId: string;
 - *Type:* string
 
 Project Id for application services.
+
+---
+
+##### `type`<sup>Required</sup> <a name="type" id="awscdk-resources-mongodbatlas.CfnTriggerProps.property.type"></a>
+
+```typescript
+public readonly type: string;
+```
+
+- *Type:* string
+
+The trigger's type.
 
 ---
 
@@ -35574,18 +35598,6 @@ For example, if you define `function_name`, the backend duplicates it to `event_
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="name" id="awscdk-resources-mongodbatlas.CfnTriggerProps.property.name"></a>
-
-```typescript
-public readonly name: string;
-```
-
-- *Type:* string
-
-The trigger's name.
-
----
-
 ##### `profile`<sup>Optional</sup> <a name="profile" id="awscdk-resources-mongodbatlas.CfnTriggerProps.property.profile"></a>
 
 ```typescript
@@ -35607,18 +35619,6 @@ public readonly scheduleTrigger: ScheduleConfig;
 ```
 
 - *Type:* <a href="#awscdk-resources-mongodbatlas.ScheduleConfig">ScheduleConfig</a>
-
----
-
-##### `type`<sup>Optional</sup> <a name="type" id="awscdk-resources-mongodbatlas.CfnTriggerProps.property.type"></a>
-
-```typescript
-public readonly type: string;
-```
-
-- *Type:* string
-
-The trigger's type.
 
 ---
 

--- a/examples/l1-resources/trigger.ts
+++ b/examples/l1-resources/trigger.ts
@@ -1,7 +1,7 @@
 // This example creates a database user in Atlas using the L1 resources.
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { CfnTrigger,  DatabaseConfigOperationTypes } from 'awscdk-resources-mongodbatlas';
+import { CfnTrigger, DatabaseConfigOperationTypes } from 'awscdk-resources-mongodbatlas';
 
 interface AtlasStackProps {
   readonly projId: string;
@@ -23,6 +23,7 @@ export class CdkTestingStack extends cdk.Stack {
     const trigger = new CfnTrigger(this, 'ThirdPartyIntegration', {
       projectId: atlasProps.projId,
       profile: atlasProps.profile,
+      name: "mytrigger",
       type: "DATABASE",
       appId: atlasProps.appId,
       databaseTrigger: {
@@ -45,7 +46,7 @@ export class CdkTestingStack extends cdk.Stack {
 
   getContextProps(): AtlasStackProps {
     const projId = this.node.tryGetContext('projId');
-    if (!projId){
+    if (!projId) {
       throw "No context value specified for projId. Please specify via the cdk context."
     }
     const appId = this.node.tryGetContext('appId');
@@ -55,14 +56,14 @@ export class CdkTestingStack extends cdk.Stack {
     const serviceId = this.node.tryGetContext('serviceId');
     const functionId = this.node.tryGetContext('functionId');
     const functionName = this.node.tryGetContext('functionName');
-    
+
     return {
       projId,
       profile,
       appId,
       dbName,
       collection,
-      serviceId, 
+      serviceId,
       functionId,
       functionName
     }

--- a/src/l1-resources/trigger/index.ts
+++ b/src/l1-resources/trigger/index.ts
@@ -35,14 +35,14 @@ export interface CfnTriggerProps {
    *
    * @schema CfnTriggerProps#Name
    */
-  readonly name?: string;
+  readonly name: string;
 
   /**
    * The trigger's type.
    *
    * @schema CfnTriggerProps#Type
    */
-  readonly type?: string;
+  readonly type: string;
 
   /**
    * If `true`, the trigger is disabled and does not listen for events or execute.

--- a/test/l1-resources/trigger/index.test.ts
+++ b/test/l1-resources/trigger/index.test.ts
@@ -19,6 +19,8 @@ import { CfnTrigger } from "../../../src/l1-resources/trigger";
 const RESOURCE_NAME = "MongoDB::Atlas::Trigger";
 const PROJECT_ID = "testProjectId";
 const APPID = "appId";
+const NAME = "name";
+const TYPE = "type";
 
 test("Trigger construct should contain default properties", () => {
   const mockApp = new App();
@@ -27,6 +29,8 @@ test("Trigger construct should contain default properties", () => {
   new CfnTrigger(stack, "testing-stack", {
     projectId: PROJECT_ID,
     appId: APPID,
+    name: NAME,
+    type: TYPE,
   });
 
   const template = Template.fromStack(stack);
@@ -34,5 +38,7 @@ test("Trigger construct should contain default properties", () => {
   template.hasResourceProperties(RESOURCE_NAME, {
     ProjectId: PROJECT_ID,
     AppId: APPID,
+    Name: NAME,
+    Type: TYPE,
   });
 });


### PR DESCRIPTION
Fixes trigger attributes name and type that are required but were as optional

_Jira ticket:_ CLOUDP-234255

Helps to fix: https://github.com/mongodb/awscdk-resources-mongodbatlas/issues/222

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
