### PR TITLE
fix: Fixes export visibility for access-list-api-key, api-key and data-lake-pipeline

### DIFF
--- a/API.md
+++ b/API.md
@@ -805,6 +805,631 @@ public readonly mserverless: CfnServerlessInstance;
 ---
 
 
+### CfnAccessListApiKey <a name="CfnAccessListApiKey" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey"></a>
+
+A CloudFormation `MongoDB::Atlas::AccessListAPIKey`.
+
+#### Initializers <a name="Initializers" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.Initializer"></a>
+
+```typescript
+import { CfnAccessListApiKey } from 'awscdk-resources-mongodbatlas'
+
+new CfnAccessListApiKey(scope: Construct, id: string, props: CfnAccessListApiKeyProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - scope in which this resource is defined. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.Initializer.parameter.id">id</a></code> | <code>string</code> | - scoped id of the resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.Initializer.parameter.props">props</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps">CfnAccessListApiKeyProps</a></code> | - resource properties. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+scope in which this resource is defined.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+scoped id of the resource.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps">CfnAccessListApiKeyProps</a>
+
+resource properties.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.overrideLogicalId">overrideLogicalId</a></code> | Overrides the auto-generated logical ID with a specific ID. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDeletionOverride">addDeletionOverride</a></code> | Syntactic sugar for `addOverride(path, undefined)`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDependency">addDependency</a></code> | Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDependsOn">addDependsOn</a></code> | Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addMetadata">addMetadata</a></code> | Add a value to the CloudFormation Resource Metadata. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.obtainResourceDependencies">obtainResourceDependencies</a></code> | Get a shallow copy of dependencies between this resource and other resources in the same stack. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.removeDependency">removeDependency</a></code> | Indicates that this resource no longer depends on another resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.replaceDependency">replaceDependency</a></code> | Replaces one dependency with another. |
+
+---
+
+##### `toString` <a name="toString" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `overrideLogicalId` <a name="overrideLogicalId" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.overrideLogicalId"></a>
+
+```typescript
+public overrideLogicalId(newLogicalId: string): void
+```
+
+Overrides the auto-generated logical ID with a specific ID.
+
+###### `newLogicalId`<sup>Required</sup> <a name="newLogicalId" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.overrideLogicalId.parameter.newLogicalId"></a>
+
+- *Type:* string
+
+The new logical ID to use for this stack element.
+
+---
+
+##### `addDeletionOverride` <a name="addDeletionOverride" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDeletionOverride"></a>
+
+```typescript
+public addDeletionOverride(path: string): void
+```
+
+Syntactic sugar for `addOverride(path, undefined)`.
+
+###### `path`<sup>Required</sup> <a name="path" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDeletionOverride.parameter.path"></a>
+
+- *Type:* string
+
+The path of the value to delete.
+
+---
+
+##### `addDependency` <a name="addDependency" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDependency"></a>
+
+```typescript
+public addDependency(target: CfnResource): void
+```
+
+Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
+
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### ~~`addDependsOn`~~ <a name="addDependsOn" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDependsOn"></a>
+
+```typescript
+public addDependsOn(target: CfnResource): void
+```
+
+Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addDependsOn.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### `addMetadata` <a name="addMetadata" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addMetadata"></a>
+
+```typescript
+public addMetadata(key: string, value: any): void
+```
+
+Add a value to the CloudFormation Resource Metadata.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.)
+
+###### `key`<sup>Required</sup> <a name="key" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addMetadata.parameter.key"></a>
+
+- *Type:* string
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addMetadata.parameter.value"></a>
+
+- *Type:* any
+
+---
+
+##### `addOverride` <a name="addOverride" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addOverride"></a>
+
+```typescript
+public addOverride(path: string, value: any): void
+```
+
+Adds an override to the synthesized CloudFormation resource.
+
+To add a
+property override, either use `addPropertyOverride` or prefix `path` with
+"Properties." (i.e. `Properties.TopicName`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal `.` in the property name, prefix with a `\`. In most
+programming languages you will need to write this as `"\\."` because the
+`\` itself will need to be escaped.
+
+For example,
+```typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+```
+would add the overrides
+```json
+"Properties": {
+  "GlobalSecondaryIndexes": [
+    {
+      "Projection": {
+        "NonKeyAttributes": [ "myattribute" ]
+        ...
+      }
+      ...
+    },
+    {
+      "ProjectionType": "INCLUDE"
+      ...
+    },
+  ]
+  ...
+}
+```
+
+The `value` argument to `addOverride` will not be processed or translated
+in any way. Pass raw JSON values in here with the correct capitalization
+for CloudFormation. If you pass CDK classes or structs, they will be
+rendered with lowercased key names, and CloudFormation will reject the
+template.
+
+###### `path`<sup>Required</sup> <a name="path" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addOverride.parameter.path"></a>
+
+- *Type:* string
+
+The path of the property, you can use dot notation to override values in complex types.
+
+Any intermediate keys
+will be created as needed.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addOverride.parameter.value"></a>
+
+- *Type:* any
+
+The value.
+
+Could be primitive or complex.
+
+---
+
+##### `addPropertyDeletionOverride` <a name="addPropertyDeletionOverride" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyDeletionOverride"></a>
+
+```typescript
+public addPropertyDeletionOverride(propertyPath: string): void
+```
+
+Adds an override that deletes the value of a property from the resource definition.
+
+###### `propertyPath`<sup>Required</sup> <a name="propertyPath" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyDeletionOverride.parameter.propertyPath"></a>
+
+- *Type:* string
+
+The path to the property.
+
+---
+
+##### `addPropertyOverride` <a name="addPropertyOverride" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyOverride"></a>
+
+```typescript
+public addPropertyOverride(propertyPath: string, value: any): void
+```
+
+Adds an override to a resource property.
+
+Syntactic sugar for `addOverride("Properties.<...>", value)`.
+
+###### `propertyPath`<sup>Required</sup> <a name="propertyPath" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyOverride.parameter.propertyPath"></a>
+
+- *Type:* string
+
+The path of the property.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyOverride.parameter.value"></a>
+
+- *Type:* any
+
+The value.
+
+---
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy?: RemovalPolicy, options?: RemovalPolicyOptions): void
+```
+
+Sets the deletion policy of the resource based on the removal policy specified.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`). In some
+cases, a snapshot can be taken of the resource prior to deletion
+(`RemovalPolicy.SNAPSHOT`). A list of resources that support this policy
+can be found in the following link:
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html#aws-attribute-deletionpolicy-options](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html#aws-attribute-deletionpolicy-options)
+
+###### `policy`<sup>Optional</sup> <a name="policy" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyRemovalPolicy.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `getAtt` <a name="getAtt" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.getAtt"></a>
+
+```typescript
+public getAtt(attributeName: string, typeHint?: ResolutionTypeHint): Reference
+```
+
+Returns a token for an runtime attribute of this resource.
+
+Ideally, use generated attribute accessors (e.g. `resource.arn`), but this can be used for future compatibility
+in case there is no generated attribute.
+
+###### `attributeName`<sup>Required</sup> <a name="attributeName" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.getAtt.parameter.attributeName"></a>
+
+- *Type:* string
+
+The name of the attribute.
+
+---
+
+###### `typeHint`<sup>Optional</sup> <a name="typeHint" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.getAtt.parameter.typeHint"></a>
+
+- *Type:* aws-cdk-lib.ResolutionTypeHint
+
+---
+
+##### `getMetadata` <a name="getMetadata" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.getMetadata"></a>
+
+```typescript
+public getMetadata(key: string): any
+```
+
+Retrieve a value value from the CloudFormation Resource Metadata.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.)
+
+###### `key`<sup>Required</sup> <a name="key" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.getMetadata.parameter.key"></a>
+
+- *Type:* string
+
+---
+
+##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.obtainDependencies"></a>
+
+```typescript
+public obtainDependencies(): Stack | CfnResource[]
+```
+
+Retrieves an array of resources this resource depends on.
+
+This assembles dependencies on resources across stacks (including nested stacks)
+automatically.
+
+##### `obtainResourceDependencies` <a name="obtainResourceDependencies" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.obtainResourceDependencies"></a>
+
+```typescript
+public obtainResourceDependencies(): CfnResource[]
+```
+
+Get a shallow copy of dependencies between this resource and other resources in the same stack.
+
+##### `removeDependency` <a name="removeDependency" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.removeDependency"></a>
+
+```typescript
+public removeDependency(target: CfnResource): void
+```
+
+Indicates that this resource no longer depends on another resource.
+
+This can be used for resources across stacks (including nested stacks)
+and the dependency will automatically be removed from the relevant scope.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.removeDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### `replaceDependency` <a name="replaceDependency" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.replaceDependency"></a>
+
+```typescript
+public replaceDependency(target: CfnResource, newTarget: CfnResource): void
+```
+
+Replaces one dependency with another.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.replaceDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+The dependency to replace.
+
+---
+
+###### `newTarget`<sup>Required</sup> <a name="newTarget" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.replaceDependency.parameter.newTarget"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+The new dependency to add.
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.isCfnElement">isCfnElement</a></code> | Returns `true` if a construct is a stack element (i.e. part of the synthesized cloudformation template). |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.isCfnResource">isCfnResource</a></code> | Check whether the given construct is a CfnResource. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.isConstruct"></a>
+
+```typescript
+import { CfnAccessListApiKey } from 'awscdk-resources-mongodbatlas'
+
+CfnAccessListApiKey.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isCfnElement` <a name="isCfnElement" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.isCfnElement"></a>
+
+```typescript
+import { CfnAccessListApiKey } from 'awscdk-resources-mongodbatlas'
+
+CfnAccessListApiKey.isCfnElement(x: any)
+```
+
+Returns `true` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
+
+Uses duck-typing instead of `instanceof` to allow stack elements from different
+versions of this library to be included in the same stack.
+
+###### `x`<sup>Required</sup> <a name="x" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.isCfnElement.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+##### `isCfnResource` <a name="isCfnResource" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.isCfnResource"></a>
+
+```typescript
+import { CfnAccessListApiKey } from 'awscdk-resources-mongodbatlas'
+
+CfnAccessListApiKey.isCfnResource(construct: IConstruct)
+```
+
+Check whether the given construct is a CfnResource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.isCfnResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.creationStack">creationStack</a></code> | <code>string[]</code> | *No description.* |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.logicalId">logicalId</a></code> | <code>string</code> | The logical ID for this CloudFormation stack element. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this element is defined. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.ref">ref</a></code> | <code>string</code> | Return a string that will be resolved to a CloudFormation `{ Ref }` for this element. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.cfnOptions">cfnOptions</a></code> | <code>aws-cdk-lib.ICfnResourceOptions</code> | Options for this resource, such as condition, update policy etc. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.cfnResourceType">cfnResourceType</a></code> | <code>string</code> | AWS resource type. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.props">props</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps">CfnAccessListApiKeyProps</a></code> | Resource props. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `creationStack`<sup>Required</sup> <a name="creationStack" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.creationStack"></a>
+
+```typescript
+public readonly creationStack: string[];
+```
+
+- *Type:* string[]
+
+---
+
+##### `logicalId`<sup>Required</sup> <a name="logicalId" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.logicalId"></a>
+
+```typescript
+public readonly logicalId: string;
+```
+
+- *Type:* string
+
+The logical ID for this CloudFormation stack element.
+
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use `overrideLogicalId(newLogicalId)`.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this element is defined.
+
+CfnElements must be defined within a stack scope (directly or indirectly).
+
+---
+
+##### `ref`<sup>Required</sup> <a name="ref" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.ref"></a>
+
+```typescript
+public readonly ref: string;
+```
+
+- *Type:* string
+
+Return a string that will be resolved to a CloudFormation `{ Ref }` for this element.
+
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through `Lazy.any({ produce: resource.ref })`.
+
+---
+
+##### `cfnOptions`<sup>Required</sup> <a name="cfnOptions" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.cfnOptions"></a>
+
+```typescript
+public readonly cfnOptions: ICfnResourceOptions;
+```
+
+- *Type:* aws-cdk-lib.ICfnResourceOptions
+
+Options for this resource, such as condition, update policy etc.
+
+---
+
+##### `cfnResourceType`<sup>Required</sup> <a name="cfnResourceType" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.cfnResourceType"></a>
+
+```typescript
+public readonly cfnResourceType: string;
+```
+
+- *Type:* string
+
+AWS resource type.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.props"></a>
+
+```typescript
+public readonly props: CfnAccessListApiKeyProps;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps">CfnAccessListApiKeyProps</a>
+
+Resource props.
+
+---
+
+#### Constants <a name="Constants" id="Constants"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.CFN_RESOURCE_TYPE_NAME">CFN_RESOURCE_TYPE_NAME</a></code> | <code>string</code> | The CloudFormation resource type name for this resource class. |
+
+---
+
+##### `CFN_RESOURCE_TYPE_NAME`<sup>Required</sup> <a name="CFN_RESOURCE_TYPE_NAME" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.property.CFN_RESOURCE_TYPE_NAME"></a>
+
+```typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string;
+```
+
+- *Type:* string
+
+The CloudFormation resource type name for this resource class.
+
+---
+
 ### CfnAlertConfiguration <a name="CfnAlertConfiguration" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration"></a>
 
 A CloudFormation `MongoDB::Atlas::AlertConfiguration`.
@@ -1458,6 +2083,683 @@ Resource props.
 ---
 
 ##### `CFN_RESOURCE_TYPE_NAME`<sup>Required</sup> <a name="CFN_RESOURCE_TYPE_NAME" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration.property.CFN_RESOURCE_TYPE_NAME"></a>
+
+```typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string;
+```
+
+- *Type:* string
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### CfnApiKey <a name="CfnApiKey" id="awscdk-resources-mongodbatlas.CfnApiKey"></a>
+
+A CloudFormation `MongoDB::Atlas::APIKey`.
+
+#### Initializers <a name="Initializers" id="awscdk-resources-mongodbatlas.CfnApiKey.Initializer"></a>
+
+```typescript
+import { CfnApiKey } from 'awscdk-resources-mongodbatlas'
+
+new CfnApiKey(scope: Construct, id: string, props: CfnApiKeyProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - scope in which this resource is defined. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.Initializer.parameter.id">id</a></code> | <code>string</code> | - scoped id of the resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.Initializer.parameter.props">props</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps">CfnApiKeyProps</a></code> | - resource properties. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="awscdk-resources-mongodbatlas.CfnApiKey.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+scope in which this resource is defined.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="awscdk-resources-mongodbatlas.CfnApiKey.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+scoped id of the resource.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="awscdk-resources-mongodbatlas.CfnApiKey.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps">CfnApiKeyProps</a>
+
+resource properties.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.overrideLogicalId">overrideLogicalId</a></code> | Overrides the auto-generated logical ID with a specific ID. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addDeletionOverride">addDeletionOverride</a></code> | Syntactic sugar for `addOverride(path, undefined)`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addDependency">addDependency</a></code> | Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addDependsOn">addDependsOn</a></code> | Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addMetadata">addMetadata</a></code> | Add a value to the CloudFormation Resource Metadata. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.obtainResourceDependencies">obtainResourceDependencies</a></code> | Get a shallow copy of dependencies between this resource and other resources in the same stack. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.removeDependency">removeDependency</a></code> | Indicates that this resource no longer depends on another resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.replaceDependency">replaceDependency</a></code> | Replaces one dependency with another. |
+
+---
+
+##### `toString` <a name="toString" id="awscdk-resources-mongodbatlas.CfnApiKey.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `overrideLogicalId` <a name="overrideLogicalId" id="awscdk-resources-mongodbatlas.CfnApiKey.overrideLogicalId"></a>
+
+```typescript
+public overrideLogicalId(newLogicalId: string): void
+```
+
+Overrides the auto-generated logical ID with a specific ID.
+
+###### `newLogicalId`<sup>Required</sup> <a name="newLogicalId" id="awscdk-resources-mongodbatlas.CfnApiKey.overrideLogicalId.parameter.newLogicalId"></a>
+
+- *Type:* string
+
+The new logical ID to use for this stack element.
+
+---
+
+##### `addDeletionOverride` <a name="addDeletionOverride" id="awscdk-resources-mongodbatlas.CfnApiKey.addDeletionOverride"></a>
+
+```typescript
+public addDeletionOverride(path: string): void
+```
+
+Syntactic sugar for `addOverride(path, undefined)`.
+
+###### `path`<sup>Required</sup> <a name="path" id="awscdk-resources-mongodbatlas.CfnApiKey.addDeletionOverride.parameter.path"></a>
+
+- *Type:* string
+
+The path of the value to delete.
+
+---
+
+##### `addDependency` <a name="addDependency" id="awscdk-resources-mongodbatlas.CfnApiKey.addDependency"></a>
+
+```typescript
+public addDependency(target: CfnResource): void
+```
+
+Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
+
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnApiKey.addDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### ~~`addDependsOn`~~ <a name="addDependsOn" id="awscdk-resources-mongodbatlas.CfnApiKey.addDependsOn"></a>
+
+```typescript
+public addDependsOn(target: CfnResource): void
+```
+
+Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnApiKey.addDependsOn.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### `addMetadata` <a name="addMetadata" id="awscdk-resources-mongodbatlas.CfnApiKey.addMetadata"></a>
+
+```typescript
+public addMetadata(key: string, value: any): void
+```
+
+Add a value to the CloudFormation Resource Metadata.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.)
+
+###### `key`<sup>Required</sup> <a name="key" id="awscdk-resources-mongodbatlas.CfnApiKey.addMetadata.parameter.key"></a>
+
+- *Type:* string
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnApiKey.addMetadata.parameter.value"></a>
+
+- *Type:* any
+
+---
+
+##### `addOverride` <a name="addOverride" id="awscdk-resources-mongodbatlas.CfnApiKey.addOverride"></a>
+
+```typescript
+public addOverride(path: string, value: any): void
+```
+
+Adds an override to the synthesized CloudFormation resource.
+
+To add a
+property override, either use `addPropertyOverride` or prefix `path` with
+"Properties." (i.e. `Properties.TopicName`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal `.` in the property name, prefix with a `\`. In most
+programming languages you will need to write this as `"\\."` because the
+`\` itself will need to be escaped.
+
+For example,
+```typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+```
+would add the overrides
+```json
+"Properties": {
+  "GlobalSecondaryIndexes": [
+    {
+      "Projection": {
+        "NonKeyAttributes": [ "myattribute" ]
+        ...
+      }
+      ...
+    },
+    {
+      "ProjectionType": "INCLUDE"
+      ...
+    },
+  ]
+  ...
+}
+```
+
+The `value` argument to `addOverride` will not be processed or translated
+in any way. Pass raw JSON values in here with the correct capitalization
+for CloudFormation. If you pass CDK classes or structs, they will be
+rendered with lowercased key names, and CloudFormation will reject the
+template.
+
+###### `path`<sup>Required</sup> <a name="path" id="awscdk-resources-mongodbatlas.CfnApiKey.addOverride.parameter.path"></a>
+
+- *Type:* string
+
+The path of the property, you can use dot notation to override values in complex types.
+
+Any intermediate keys
+will be created as needed.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnApiKey.addOverride.parameter.value"></a>
+
+- *Type:* any
+
+The value.
+
+Could be primitive or complex.
+
+---
+
+##### `addPropertyDeletionOverride` <a name="addPropertyDeletionOverride" id="awscdk-resources-mongodbatlas.CfnApiKey.addPropertyDeletionOverride"></a>
+
+```typescript
+public addPropertyDeletionOverride(propertyPath: string): void
+```
+
+Adds an override that deletes the value of a property from the resource definition.
+
+###### `propertyPath`<sup>Required</sup> <a name="propertyPath" id="awscdk-resources-mongodbatlas.CfnApiKey.addPropertyDeletionOverride.parameter.propertyPath"></a>
+
+- *Type:* string
+
+The path to the property.
+
+---
+
+##### `addPropertyOverride` <a name="addPropertyOverride" id="awscdk-resources-mongodbatlas.CfnApiKey.addPropertyOverride"></a>
+
+```typescript
+public addPropertyOverride(propertyPath: string, value: any): void
+```
+
+Adds an override to a resource property.
+
+Syntactic sugar for `addOverride("Properties.<...>", value)`.
+
+###### `propertyPath`<sup>Required</sup> <a name="propertyPath" id="awscdk-resources-mongodbatlas.CfnApiKey.addPropertyOverride.parameter.propertyPath"></a>
+
+- *Type:* string
+
+The path of the property.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnApiKey.addPropertyOverride.parameter.value"></a>
+
+- *Type:* any
+
+The value.
+
+---
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnApiKey.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy?: RemovalPolicy, options?: RemovalPolicyOptions): void
+```
+
+Sets the deletion policy of the resource based on the removal policy specified.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`). In some
+cases, a snapshot can be taken of the resource prior to deletion
+(`RemovalPolicy.SNAPSHOT`). A list of resources that support this policy
+can be found in the following link:
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html#aws-attribute-deletionpolicy-options](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html#aws-attribute-deletionpolicy-options)
+
+###### `policy`<sup>Optional</sup> <a name="policy" id="awscdk-resources-mongodbatlas.CfnApiKey.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnApiKey.applyRemovalPolicy.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `getAtt` <a name="getAtt" id="awscdk-resources-mongodbatlas.CfnApiKey.getAtt"></a>
+
+```typescript
+public getAtt(attributeName: string, typeHint?: ResolutionTypeHint): Reference
+```
+
+Returns a token for an runtime attribute of this resource.
+
+Ideally, use generated attribute accessors (e.g. `resource.arn`), but this can be used for future compatibility
+in case there is no generated attribute.
+
+###### `attributeName`<sup>Required</sup> <a name="attributeName" id="awscdk-resources-mongodbatlas.CfnApiKey.getAtt.parameter.attributeName"></a>
+
+- *Type:* string
+
+The name of the attribute.
+
+---
+
+###### `typeHint`<sup>Optional</sup> <a name="typeHint" id="awscdk-resources-mongodbatlas.CfnApiKey.getAtt.parameter.typeHint"></a>
+
+- *Type:* aws-cdk-lib.ResolutionTypeHint
+
+---
+
+##### `getMetadata` <a name="getMetadata" id="awscdk-resources-mongodbatlas.CfnApiKey.getMetadata"></a>
+
+```typescript
+public getMetadata(key: string): any
+```
+
+Retrieve a value value from the CloudFormation Resource Metadata.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.)
+
+###### `key`<sup>Required</sup> <a name="key" id="awscdk-resources-mongodbatlas.CfnApiKey.getMetadata.parameter.key"></a>
+
+- *Type:* string
+
+---
+
+##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnApiKey.obtainDependencies"></a>
+
+```typescript
+public obtainDependencies(): Stack | CfnResource[]
+```
+
+Retrieves an array of resources this resource depends on.
+
+This assembles dependencies on resources across stacks (including nested stacks)
+automatically.
+
+##### `obtainResourceDependencies` <a name="obtainResourceDependencies" id="awscdk-resources-mongodbatlas.CfnApiKey.obtainResourceDependencies"></a>
+
+```typescript
+public obtainResourceDependencies(): CfnResource[]
+```
+
+Get a shallow copy of dependencies between this resource and other resources in the same stack.
+
+##### `removeDependency` <a name="removeDependency" id="awscdk-resources-mongodbatlas.CfnApiKey.removeDependency"></a>
+
+```typescript
+public removeDependency(target: CfnResource): void
+```
+
+Indicates that this resource no longer depends on another resource.
+
+This can be used for resources across stacks (including nested stacks)
+and the dependency will automatically be removed from the relevant scope.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnApiKey.removeDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### `replaceDependency` <a name="replaceDependency" id="awscdk-resources-mongodbatlas.CfnApiKey.replaceDependency"></a>
+
+```typescript
+public replaceDependency(target: CfnResource, newTarget: CfnResource): void
+```
+
+Replaces one dependency with another.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnApiKey.replaceDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+The dependency to replace.
+
+---
+
+###### `newTarget`<sup>Required</sup> <a name="newTarget" id="awscdk-resources-mongodbatlas.CfnApiKey.replaceDependency.parameter.newTarget"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+The new dependency to add.
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.isCfnElement">isCfnElement</a></code> | Returns `true` if a construct is a stack element (i.e. part of the synthesized cloudformation template). |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.isCfnResource">isCfnResource</a></code> | Check whether the given construct is a CfnResource. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="awscdk-resources-mongodbatlas.CfnApiKey.isConstruct"></a>
+
+```typescript
+import { CfnApiKey } from 'awscdk-resources-mongodbatlas'
+
+CfnApiKey.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="awscdk-resources-mongodbatlas.CfnApiKey.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isCfnElement` <a name="isCfnElement" id="awscdk-resources-mongodbatlas.CfnApiKey.isCfnElement"></a>
+
+```typescript
+import { CfnApiKey } from 'awscdk-resources-mongodbatlas'
+
+CfnApiKey.isCfnElement(x: any)
+```
+
+Returns `true` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
+
+Uses duck-typing instead of `instanceof` to allow stack elements from different
+versions of this library to be included in the same stack.
+
+###### `x`<sup>Required</sup> <a name="x" id="awscdk-resources-mongodbatlas.CfnApiKey.isCfnElement.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+##### `isCfnResource` <a name="isCfnResource" id="awscdk-resources-mongodbatlas.CfnApiKey.isCfnResource"></a>
+
+```typescript
+import { CfnApiKey } from 'awscdk-resources-mongodbatlas'
+
+CfnApiKey.isCfnResource(construct: IConstruct)
+```
+
+Check whether the given construct is a CfnResource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="awscdk-resources-mongodbatlas.CfnApiKey.isCfnResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.creationStack">creationStack</a></code> | <code>string[]</code> | *No description.* |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.logicalId">logicalId</a></code> | <code>string</code> | The logical ID for this CloudFormation stack element. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this element is defined. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.ref">ref</a></code> | <code>string</code> | Return a string that will be resolved to a CloudFormation `{ Ref }` for this element. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.cfnOptions">cfnOptions</a></code> | <code>aws-cdk-lib.ICfnResourceOptions</code> | Options for this resource, such as condition, update policy etc. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.cfnResourceType">cfnResourceType</a></code> | <code>string</code> | AWS resource type. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.attrAPIUserId">attrAPIUserId</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::APIKey.APIUserId`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.attrAwsSecretArn">attrAwsSecretArn</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::APIKey.AwsSecretArn`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.attrPrivateKey">attrPrivateKey</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::APIKey.PrivateKey`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.attrPublicKey">attrPublicKey</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::APIKey.PublicKey`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.props">props</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps">CfnApiKeyProps</a></code> | Resource props. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="awscdk-resources-mongodbatlas.CfnApiKey.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `creationStack`<sup>Required</sup> <a name="creationStack" id="awscdk-resources-mongodbatlas.CfnApiKey.property.creationStack"></a>
+
+```typescript
+public readonly creationStack: string[];
+```
+
+- *Type:* string[]
+
+---
+
+##### `logicalId`<sup>Required</sup> <a name="logicalId" id="awscdk-resources-mongodbatlas.CfnApiKey.property.logicalId"></a>
+
+```typescript
+public readonly logicalId: string;
+```
+
+- *Type:* string
+
+The logical ID for this CloudFormation stack element.
+
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use `overrideLogicalId(newLogicalId)`.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="awscdk-resources-mongodbatlas.CfnApiKey.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this element is defined.
+
+CfnElements must be defined within a stack scope (directly or indirectly).
+
+---
+
+##### `ref`<sup>Required</sup> <a name="ref" id="awscdk-resources-mongodbatlas.CfnApiKey.property.ref"></a>
+
+```typescript
+public readonly ref: string;
+```
+
+- *Type:* string
+
+Return a string that will be resolved to a CloudFormation `{ Ref }` for this element.
+
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through `Lazy.any({ produce: resource.ref })`.
+
+---
+
+##### `cfnOptions`<sup>Required</sup> <a name="cfnOptions" id="awscdk-resources-mongodbatlas.CfnApiKey.property.cfnOptions"></a>
+
+```typescript
+public readonly cfnOptions: ICfnResourceOptions;
+```
+
+- *Type:* aws-cdk-lib.ICfnResourceOptions
+
+Options for this resource, such as condition, update policy etc.
+
+---
+
+##### `cfnResourceType`<sup>Required</sup> <a name="cfnResourceType" id="awscdk-resources-mongodbatlas.CfnApiKey.property.cfnResourceType"></a>
+
+```typescript
+public readonly cfnResourceType: string;
+```
+
+- *Type:* string
+
+AWS resource type.
+
+---
+
+##### `attrAPIUserId`<sup>Required</sup> <a name="attrAPIUserId" id="awscdk-resources-mongodbatlas.CfnApiKey.property.attrAPIUserId"></a>
+
+```typescript
+public readonly attrAPIUserId: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::APIKey.APIUserId`.
+
+---
+
+##### `attrAwsSecretArn`<sup>Required</sup> <a name="attrAwsSecretArn" id="awscdk-resources-mongodbatlas.CfnApiKey.property.attrAwsSecretArn"></a>
+
+```typescript
+public readonly attrAwsSecretArn: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::APIKey.AwsSecretArn`.
+
+---
+
+##### `attrPrivateKey`<sup>Required</sup> <a name="attrPrivateKey" id="awscdk-resources-mongodbatlas.CfnApiKey.property.attrPrivateKey"></a>
+
+```typescript
+public readonly attrPrivateKey: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::APIKey.PrivateKey`.
+
+---
+
+##### `attrPublicKey`<sup>Required</sup> <a name="attrPublicKey" id="awscdk-resources-mongodbatlas.CfnApiKey.property.attrPublicKey"></a>
+
+```typescript
+public readonly attrPublicKey: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::APIKey.PublicKey`.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="awscdk-resources-mongodbatlas.CfnApiKey.property.props"></a>
+
+```typescript
+public readonly props: CfnApiKeyProps;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps">CfnApiKeyProps</a>
+
+Resource props.
+
+---
+
+#### Constants <a name="Constants" id="Constants"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.property.CFN_RESOURCE_TYPE_NAME">CFN_RESOURCE_TYPE_NAME</a></code> | <code>string</code> | The CloudFormation resource type name for this resource class. |
+
+---
+
+##### `CFN_RESOURCE_TYPE_NAME`<sup>Required</sup> <a name="CFN_RESOURCE_TYPE_NAME" id="awscdk-resources-mongodbatlas.CfnApiKey.property.CFN_RESOURCE_TYPE_NAME"></a>
 
 ```typescript
 public readonly CFN_RESOURCE_TYPE_NAME: string;
@@ -8124,6 +9426,670 @@ Resource props.
 ---
 
 ##### `CFN_RESOURCE_TYPE_NAME`<sup>Required</sup> <a name="CFN_RESOURCE_TYPE_NAME" id="awscdk-resources-mongodbatlas.CfnDatabaseUser.property.CFN_RESOURCE_TYPE_NAME"></a>
+
+```typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string;
+```
+
+- *Type:* string
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### CfnDataLakePipeline <a name="CfnDataLakePipeline" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline"></a>
+
+A CloudFormation `MongoDB::Atlas::DataLakePipeline`.
+
+#### Initializers <a name="Initializers" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.Initializer"></a>
+
+```typescript
+import { CfnDataLakePipeline } from 'awscdk-resources-mongodbatlas'
+
+new CfnDataLakePipeline(scope: Construct, id: string, props: CfnDataLakePipelineProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - scope in which this resource is defined. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.Initializer.parameter.id">id</a></code> | <code>string</code> | - scoped id of the resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.Initializer.parameter.props">props</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps">CfnDataLakePipelineProps</a></code> | - resource properties. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+scope in which this resource is defined.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+scoped id of the resource.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps">CfnDataLakePipelineProps</a>
+
+resource properties.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.overrideLogicalId">overrideLogicalId</a></code> | Overrides the auto-generated logical ID with a specific ID. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDeletionOverride">addDeletionOverride</a></code> | Syntactic sugar for `addOverride(path, undefined)`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDependency">addDependency</a></code> | Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDependsOn">addDependsOn</a></code> | Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.addMetadata">addMetadata</a></code> | Add a value to the CloudFormation Resource Metadata. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.obtainResourceDependencies">obtainResourceDependencies</a></code> | Get a shallow copy of dependencies between this resource and other resources in the same stack. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.removeDependency">removeDependency</a></code> | Indicates that this resource no longer depends on another resource. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.replaceDependency">replaceDependency</a></code> | Replaces one dependency with another. |
+
+---
+
+##### `toString` <a name="toString" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `overrideLogicalId` <a name="overrideLogicalId" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.overrideLogicalId"></a>
+
+```typescript
+public overrideLogicalId(newLogicalId: string): void
+```
+
+Overrides the auto-generated logical ID with a specific ID.
+
+###### `newLogicalId`<sup>Required</sup> <a name="newLogicalId" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.overrideLogicalId.parameter.newLogicalId"></a>
+
+- *Type:* string
+
+The new logical ID to use for this stack element.
+
+---
+
+##### `addDeletionOverride` <a name="addDeletionOverride" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDeletionOverride"></a>
+
+```typescript
+public addDeletionOverride(path: string): void
+```
+
+Syntactic sugar for `addOverride(path, undefined)`.
+
+###### `path`<sup>Required</sup> <a name="path" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDeletionOverride.parameter.path"></a>
+
+- *Type:* string
+
+The path of the value to delete.
+
+---
+
+##### `addDependency` <a name="addDependency" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDependency"></a>
+
+```typescript
+public addDependency(target: CfnResource): void
+```
+
+Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
+
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### ~~`addDependsOn`~~ <a name="addDependsOn" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDependsOn"></a>
+
+```typescript
+public addDependsOn(target: CfnResource): void
+```
+
+Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addDependsOn.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### `addMetadata` <a name="addMetadata" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addMetadata"></a>
+
+```typescript
+public addMetadata(key: string, value: any): void
+```
+
+Add a value to the CloudFormation Resource Metadata.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.)
+
+###### `key`<sup>Required</sup> <a name="key" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addMetadata.parameter.key"></a>
+
+- *Type:* string
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addMetadata.parameter.value"></a>
+
+- *Type:* any
+
+---
+
+##### `addOverride` <a name="addOverride" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addOverride"></a>
+
+```typescript
+public addOverride(path: string, value: any): void
+```
+
+Adds an override to the synthesized CloudFormation resource.
+
+To add a
+property override, either use `addPropertyOverride` or prefix `path` with
+"Properties." (i.e. `Properties.TopicName`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal `.` in the property name, prefix with a `\`. In most
+programming languages you will need to write this as `"\\."` because the
+`\` itself will need to be escaped.
+
+For example,
+```typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+```
+would add the overrides
+```json
+"Properties": {
+  "GlobalSecondaryIndexes": [
+    {
+      "Projection": {
+        "NonKeyAttributes": [ "myattribute" ]
+        ...
+      }
+      ...
+    },
+    {
+      "ProjectionType": "INCLUDE"
+      ...
+    },
+  ]
+  ...
+}
+```
+
+The `value` argument to `addOverride` will not be processed or translated
+in any way. Pass raw JSON values in here with the correct capitalization
+for CloudFormation. If you pass CDK classes or structs, they will be
+rendered with lowercased key names, and CloudFormation will reject the
+template.
+
+###### `path`<sup>Required</sup> <a name="path" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addOverride.parameter.path"></a>
+
+- *Type:* string
+
+The path of the property, you can use dot notation to override values in complex types.
+
+Any intermediate keys
+will be created as needed.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addOverride.parameter.value"></a>
+
+- *Type:* any
+
+The value.
+
+Could be primitive or complex.
+
+---
+
+##### `addPropertyDeletionOverride` <a name="addPropertyDeletionOverride" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addPropertyDeletionOverride"></a>
+
+```typescript
+public addPropertyDeletionOverride(propertyPath: string): void
+```
+
+Adds an override that deletes the value of a property from the resource definition.
+
+###### `propertyPath`<sup>Required</sup> <a name="propertyPath" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addPropertyDeletionOverride.parameter.propertyPath"></a>
+
+- *Type:* string
+
+The path to the property.
+
+---
+
+##### `addPropertyOverride` <a name="addPropertyOverride" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addPropertyOverride"></a>
+
+```typescript
+public addPropertyOverride(propertyPath: string, value: any): void
+```
+
+Adds an override to a resource property.
+
+Syntactic sugar for `addOverride("Properties.<...>", value)`.
+
+###### `propertyPath`<sup>Required</sup> <a name="propertyPath" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addPropertyOverride.parameter.propertyPath"></a>
+
+- *Type:* string
+
+The path of the property.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.addPropertyOverride.parameter.value"></a>
+
+- *Type:* any
+
+The value.
+
+---
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy?: RemovalPolicy, options?: RemovalPolicyOptions): void
+```
+
+Sets the deletion policy of the resource based on the removal policy specified.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`). In some
+cases, a snapshot can be taken of the resource prior to deletion
+(`RemovalPolicy.SNAPSHOT`). A list of resources that support this policy
+can be found in the following link:
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html#aws-attribute-deletionpolicy-options](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html#aws-attribute-deletionpolicy-options)
+
+###### `policy`<sup>Optional</sup> <a name="policy" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.applyRemovalPolicy.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `getAtt` <a name="getAtt" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.getAtt"></a>
+
+```typescript
+public getAtt(attributeName: string, typeHint?: ResolutionTypeHint): Reference
+```
+
+Returns a token for an runtime attribute of this resource.
+
+Ideally, use generated attribute accessors (e.g. `resource.arn`), but this can be used for future compatibility
+in case there is no generated attribute.
+
+###### `attributeName`<sup>Required</sup> <a name="attributeName" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.getAtt.parameter.attributeName"></a>
+
+- *Type:* string
+
+The name of the attribute.
+
+---
+
+###### `typeHint`<sup>Optional</sup> <a name="typeHint" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.getAtt.parameter.typeHint"></a>
+
+- *Type:* aws-cdk-lib.ResolutionTypeHint
+
+---
+
+##### `getMetadata` <a name="getMetadata" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.getMetadata"></a>
+
+```typescript
+public getMetadata(key: string): any
+```
+
+Retrieve a value value from the CloudFormation Resource Metadata.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+
+Note that this is a different set of metadata from CDK node metadata; this
+metadata ends up in the stack template under the resource, whereas CDK
+node metadata ends up in the Cloud Assembly.)
+
+###### `key`<sup>Required</sup> <a name="key" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.getMetadata.parameter.key"></a>
+
+- *Type:* string
+
+---
+
+##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.obtainDependencies"></a>
+
+```typescript
+public obtainDependencies(): Stack | CfnResource[]
+```
+
+Retrieves an array of resources this resource depends on.
+
+This assembles dependencies on resources across stacks (including nested stacks)
+automatically.
+
+##### `obtainResourceDependencies` <a name="obtainResourceDependencies" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.obtainResourceDependencies"></a>
+
+```typescript
+public obtainResourceDependencies(): CfnResource[]
+```
+
+Get a shallow copy of dependencies between this resource and other resources in the same stack.
+
+##### `removeDependency` <a name="removeDependency" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.removeDependency"></a>
+
+```typescript
+public removeDependency(target: CfnResource): void
+```
+
+Indicates that this resource no longer depends on another resource.
+
+This can be used for resources across stacks (including nested stacks)
+and the dependency will automatically be removed from the relevant scope.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.removeDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+---
+
+##### `replaceDependency` <a name="replaceDependency" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.replaceDependency"></a>
+
+```typescript
+public replaceDependency(target: CfnResource, newTarget: CfnResource): void
+```
+
+Replaces one dependency with another.
+
+###### `target`<sup>Required</sup> <a name="target" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.replaceDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+The dependency to replace.
+
+---
+
+###### `newTarget`<sup>Required</sup> <a name="newTarget" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.replaceDependency.parameter.newTarget"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+The new dependency to add.
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.isCfnElement">isCfnElement</a></code> | Returns `true` if a construct is a stack element (i.e. part of the synthesized cloudformation template). |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.isCfnResource">isCfnResource</a></code> | Check whether the given construct is a CfnResource. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.isConstruct"></a>
+
+```typescript
+import { CfnDataLakePipeline } from 'awscdk-resources-mongodbatlas'
+
+CfnDataLakePipeline.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isCfnElement` <a name="isCfnElement" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.isCfnElement"></a>
+
+```typescript
+import { CfnDataLakePipeline } from 'awscdk-resources-mongodbatlas'
+
+CfnDataLakePipeline.isCfnElement(x: any)
+```
+
+Returns `true` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
+
+Uses duck-typing instead of `instanceof` to allow stack elements from different
+versions of this library to be included in the same stack.
+
+###### `x`<sup>Required</sup> <a name="x" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.isCfnElement.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+##### `isCfnResource` <a name="isCfnResource" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.isCfnResource"></a>
+
+```typescript
+import { CfnDataLakePipeline } from 'awscdk-resources-mongodbatlas'
+
+CfnDataLakePipeline.isCfnResource(construct: IConstruct)
+```
+
+Check whether the given construct is a CfnResource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.isCfnResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.creationStack">creationStack</a></code> | <code>string[]</code> | *No description.* |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.logicalId">logicalId</a></code> | <code>string</code> | The logical ID for this CloudFormation stack element. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this element is defined. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.ref">ref</a></code> | <code>string</code> | Return a string that will be resolved to a CloudFormation `{ Ref }` for this element. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.cfnOptions">cfnOptions</a></code> | <code>aws-cdk-lib.ICfnResourceOptions</code> | Options for this resource, such as condition, update policy etc. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.cfnResourceType">cfnResourceType</a></code> | <code>string</code> | AWS resource type. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.attrCreatedDate">attrCreatedDate</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::DataLakePipeline.CreatedDate`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.attrId">attrId</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::DataLakePipeline.Id`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.attrLastUpdatedDate">attrLastUpdatedDate</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::DataLakePipeline.LastUpdatedDate`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.props">props</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps">CfnDataLakePipelineProps</a></code> | Resource props. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `creationStack`<sup>Required</sup> <a name="creationStack" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.creationStack"></a>
+
+```typescript
+public readonly creationStack: string[];
+```
+
+- *Type:* string[]
+
+---
+
+##### `logicalId`<sup>Required</sup> <a name="logicalId" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.logicalId"></a>
+
+```typescript
+public readonly logicalId: string;
+```
+
+- *Type:* string
+
+The logical ID for this CloudFormation stack element.
+
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use `overrideLogicalId(newLogicalId)`.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this element is defined.
+
+CfnElements must be defined within a stack scope (directly or indirectly).
+
+---
+
+##### `ref`<sup>Required</sup> <a name="ref" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.ref"></a>
+
+```typescript
+public readonly ref: string;
+```
+
+- *Type:* string
+
+Return a string that will be resolved to a CloudFormation `{ Ref }` for this element.
+
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through `Lazy.any({ produce: resource.ref })`.
+
+---
+
+##### `cfnOptions`<sup>Required</sup> <a name="cfnOptions" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.cfnOptions"></a>
+
+```typescript
+public readonly cfnOptions: ICfnResourceOptions;
+```
+
+- *Type:* aws-cdk-lib.ICfnResourceOptions
+
+Options for this resource, such as condition, update policy etc.
+
+---
+
+##### `cfnResourceType`<sup>Required</sup> <a name="cfnResourceType" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.cfnResourceType"></a>
+
+```typescript
+public readonly cfnResourceType: string;
+```
+
+- *Type:* string
+
+AWS resource type.
+
+---
+
+##### `attrCreatedDate`<sup>Required</sup> <a name="attrCreatedDate" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.attrCreatedDate"></a>
+
+```typescript
+public readonly attrCreatedDate: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::DataLakePipeline.CreatedDate`.
+
+---
+
+##### `attrId`<sup>Required</sup> <a name="attrId" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.attrId"></a>
+
+```typescript
+public readonly attrId: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::DataLakePipeline.Id`.
+
+---
+
+##### `attrLastUpdatedDate`<sup>Required</sup> <a name="attrLastUpdatedDate" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.attrLastUpdatedDate"></a>
+
+```typescript
+public readonly attrLastUpdatedDate: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::DataLakePipeline.LastUpdatedDate`.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.props"></a>
+
+```typescript
+public readonly props: CfnDataLakePipelineProps;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps">CfnDataLakePipelineProps</a>
+
+Resource props.
+
+---
+
+#### Constants <a name="Constants" id="Constants"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.CFN_RESOURCE_TYPE_NAME">CFN_RESOURCE_TYPE_NAME</a></code> | <code>string</code> | The CloudFormation resource type name for this resource class. |
+
+---
+
+##### `CFN_RESOURCE_TYPE_NAME`<sup>Required</sup> <a name="CFN_RESOURCE_TYPE_NAME" id="awscdk-resources-mongodbatlas.CfnDataLakePipeline.property.CFN_RESOURCE_TYPE_NAME"></a>
 
 ```typescript
 public readonly CFN_RESOURCE_TYPE_NAME: string;
@@ -30242,6 +32208,103 @@ String Representing the AWS VPC ID (like: vpc-xxxxxxxxxxxxxxxx) (Used For Creati
 
 ---
 
+### CfnAccessListApiKeyProps <a name="CfnAccessListApiKeyProps" id="awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps"></a>
+
+Creates the access list entries for the specified organization API key.
+
+#### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.Initializer"></a>
+
+```typescript
+import { CfnAccessListApiKeyProps } from 'awscdk-resources-mongodbatlas'
+
+const cfnAccessListApiKeyProps: CfnAccessListApiKeyProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.apiUserId">apiUserId</a></code> | <code>string</code> | Unique 24-hexadecimal digit string that identifies this organization API key for which you want to return access list entries. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.orgId">orgId</a></code> | <code>string</code> | Unique 24-hexadecimal digit string that identifies the organization that contains your projects. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.cidrBlock">cidrBlock</a></code> | <code>string</code> | Range of network addresses that you want to add to the access list for the API key. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.ipAddress">ipAddress</a></code> | <code>string</code> | Network address that you want to add to the access list for the API key. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.profile">profile</a></code> | <code>string</code> | Network address that issued the most recent request to the API. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.totalCount">totalCount</a></code> | <code>number</code> | Number of documents returned in this response. |
+
+---
+
+##### `apiUserId`<sup>Required</sup> <a name="apiUserId" id="awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.apiUserId"></a>
+
+```typescript
+public readonly apiUserId: string;
+```
+
+- *Type:* string
+
+Unique 24-hexadecimal digit string that identifies this organization API key for which you want to return access list entries.
+
+---
+
+##### `orgId`<sup>Required</sup> <a name="orgId" id="awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.orgId"></a>
+
+```typescript
+public readonly orgId: string;
+```
+
+- *Type:* string
+
+Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
+
+---
+
+##### `cidrBlock`<sup>Optional</sup> <a name="cidrBlock" id="awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.cidrBlock"></a>
+
+```typescript
+public readonly cidrBlock: string;
+```
+
+- *Type:* string
+
+Range of network addresses that you want to add to the access list for the API key.
+
+---
+
+##### `ipAddress`<sup>Optional</sup> <a name="ipAddress" id="awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.ipAddress"></a>
+
+```typescript
+public readonly ipAddress: string;
+```
+
+- *Type:* string
+
+Network address that you want to add to the access list for the API key.
+
+---
+
+##### `profile`<sup>Optional</sup> <a name="profile" id="awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.profile"></a>
+
+```typescript
+public readonly profile: string;
+```
+
+- *Type:* string
+
+Network address that issued the most recent request to the API.
+
+---
+
+##### `totalCount`<sup>Optional</sup> <a name="totalCount" id="awscdk-resources-mongodbatlas.CfnAccessListApiKeyProps.property.totalCount"></a>
+
+```typescript
+public readonly totalCount: number;
+```
+
+- *Type:* number
+
+Number of documents returned in this response.
+
+---
+
 ### CfnAlertConfigurationProps <a name="CfnAlertConfigurationProps" id="awscdk-resources-mongodbatlas.CfnAlertConfigurationProps"></a>
 
 Returns and edits the conditions that trigger alerts and how MongoDB Cloud notifies users.
@@ -30385,6 +32448,120 @@ public readonly typeName: string;
 - *Type:* string
 
 Human-readable label that displays the alert type.
+
+---
+
+### CfnApiKeyProps <a name="CfnApiKeyProps" id="awscdk-resources-mongodbatlas.CfnApiKeyProps"></a>
+
+Creates one API key for the specified organization.
+
+An organization API key grants programmatic access to an organization.
+
+#### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.CfnApiKeyProps.Initializer"></a>
+
+```typescript
+import { CfnApiKeyProps } from 'awscdk-resources-mongodbatlas'
+
+const cfnApiKeyProps: CfnApiKeyProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps.property.description">description</a></code> | <code>string</code> | Purpose or explanation provided when someone created this organization API key. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps.property.orgId">orgId</a></code> | <code>string</code> | Unique 24-hexadecimal digit string that identifies the organization that contains your projects. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps.property.awsSecretName">awsSecretName</a></code> | <code>string</code> | Name of the AWS Secrets Manager secret that stores the API key Details. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps.property.listOptions">listOptions</a></code> | <code><a href="#awscdk-resources-mongodbatlas.ListOptions">ListOptions</a></code> | *No description.* |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps.property.profile">profile</a></code> | <code>string</code> | Profile used to provide credentials information, (a secret with the cfn/atlas/profile/{Profile}, is required), if not provided default is used. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps.property.projectAssignments">projectAssignments</a></code> | <code><a href="#awscdk-resources-mongodbatlas.ProjectAssignment">ProjectAssignment</a>[]</code> | *No description.* |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKeyProps.property.roles">roles</a></code> | <code>string[]</code> | List of roles to grant this API key. |
+
+---
+
+##### `description`<sup>Required</sup> <a name="description" id="awscdk-resources-mongodbatlas.CfnApiKeyProps.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Purpose or explanation provided when someone created this organization API key.
+
+---
+
+##### `orgId`<sup>Required</sup> <a name="orgId" id="awscdk-resources-mongodbatlas.CfnApiKeyProps.property.orgId"></a>
+
+```typescript
+public readonly orgId: string;
+```
+
+- *Type:* string
+
+Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
+
+Use the /orgs endpoint to retrieve all organizations to which the authenticated user has access.
+
+---
+
+##### `awsSecretName`<sup>Optional</sup> <a name="awsSecretName" id="awscdk-resources-mongodbatlas.CfnApiKeyProps.property.awsSecretName"></a>
+
+```typescript
+public readonly awsSecretName: string;
+```
+
+- *Type:* string
+
+Name of the AWS Secrets Manager secret that stores the API key Details.
+
+The secret name must be unique to the AWS account and region. If you don't specify a name, AWS CloudFormation use APIUserId for the secret name.
+
+---
+
+##### `listOptions`<sup>Optional</sup> <a name="listOptions" id="awscdk-resources-mongodbatlas.CfnApiKeyProps.property.listOptions"></a>
+
+```typescript
+public readonly listOptions: ListOptions;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.ListOptions">ListOptions</a>
+
+---
+
+##### `profile`<sup>Optional</sup> <a name="profile" id="awscdk-resources-mongodbatlas.CfnApiKeyProps.property.profile"></a>
+
+```typescript
+public readonly profile: string;
+```
+
+- *Type:* string
+
+Profile used to provide credentials information, (a secret with the cfn/atlas/profile/{Profile}, is required), if not provided default is used.
+
+---
+
+##### `projectAssignments`<sup>Optional</sup> <a name="projectAssignments" id="awscdk-resources-mongodbatlas.CfnApiKeyProps.property.projectAssignments"></a>
+
+```typescript
+public readonly projectAssignments: ProjectAssignment[];
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.ProjectAssignment">ProjectAssignment</a>[]
+
+---
+
+##### `roles`<sup>Optional</sup> <a name="roles" id="awscdk-resources-mongodbatlas.CfnApiKeyProps.property.roles"></a>
+
+```typescript
+public readonly roles: string[];
+```
+
+- *Type:* string[]
+
+List of roles to grant this API key.
+
+If you provide this list, provide a minimum of one role and ensure each role applies to this organization.
 
 ---
 
@@ -31954,6 +34131,112 @@ public readonly x509Type: CfnDatabaseUserPropsX509Type;
 Method that briefs who owns the certificate provided.
 
 Default value is `NONE`.
+
+---
+
+### CfnDataLakePipelineProps <a name="CfnDataLakePipelineProps" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps"></a>
+
+An example resource schema demonstrating some basic constructs and validation rules.
+
+#### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.Initializer"></a>
+
+```typescript
+import { CfnDataLakePipelineProps } from 'awscdk-resources-mongodbatlas'
+
+const cfnDataLakePipelineProps: CfnDataLakePipelineProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.name">name</a></code> | <code>string</code> | Name of this Data Lake Pipeline. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.projectId">projectId</a></code> | <code>string</code> | Unique 24-hexadecimal digit string that identifies your project. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.sink">sink</a></code> | <code><a href="#awscdk-resources-mongodbatlas.Sink">Sink</a></code> | *No description.* |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.transformations">transformations</a></code> | <code><a href="#awscdk-resources-mongodbatlas.Transformations">Transformations</a>[]</code> | Ingestion destination of a Data Lake Pipeline. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.profile">profile</a></code> | <code>string</code> | Profile used to provide credentials information, (a secret with the cfn/atlas/profile/{Profile}, is required), if not provided default is used. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.source">source</a></code> | <code><a href="#awscdk-resources-mongodbatlas.Source">Source</a></code> | *No description.* |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.state">state</a></code> | <code>string</code> | State of the Data Lake Pipeline. |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+Name of this Data Lake Pipeline.
+
+---
+
+##### `projectId`<sup>Required</sup> <a name="projectId" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.projectId"></a>
+
+```typescript
+public readonly projectId: string;
+```
+
+- *Type:* string
+
+Unique 24-hexadecimal digit string that identifies your project.
+
+---
+
+##### `sink`<sup>Required</sup> <a name="sink" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.sink"></a>
+
+```typescript
+public readonly sink: Sink;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.Sink">Sink</a>
+
+---
+
+##### `transformations`<sup>Required</sup> <a name="transformations" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.transformations"></a>
+
+```typescript
+public readonly transformations: Transformations[];
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.Transformations">Transformations</a>[]
+
+Ingestion destination of a Data Lake Pipeline.
+
+---
+
+##### `profile`<sup>Optional</sup> <a name="profile" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.profile"></a>
+
+```typescript
+public readonly profile: string;
+```
+
+- *Type:* string
+
+Profile used to provide credentials information, (a secret with the cfn/atlas/profile/{Profile}, is required), if not provided default is used.
+
+---
+
+##### `source`<sup>Optional</sup> <a name="source" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.source"></a>
+
+```typescript
+public readonly source: Source;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.Source">Source</a>
+
+---
+
+##### `state`<sup>Optional</sup> <a name="state" id="awscdk-resources-mongodbatlas.CfnDataLakePipelineProps.property.state"></a>
+
+```typescript
+public readonly state: string;
+```
+
+- *Type:* string
+
+State of the Data Lake Pipeline.
 
 ---
 
@@ -39066,6 +41349,53 @@ Service key associated with your PagerDuty account.
 
 ---
 
+### PartitionFields <a name="PartitionFields" id="awscdk-resources-mongodbatlas.PartitionFields"></a>
+
+Ordered fields used to physically organize data in the destination.
+
+#### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.PartitionFields.Initializer"></a>
+
+```typescript
+import { PartitionFields } from 'awscdk-resources-mongodbatlas'
+
+const partitionFields: PartitionFields = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.PartitionFields.property.fieldName">fieldName</a></code> | <code>string</code> | Human-readable label that identifies the field name used to partition data. |
+| <code><a href="#awscdk-resources-mongodbatlas.PartitionFields.property.order">order</a></code> | <code>number</code> | Sequence in which MongoDB Cloud slices the collection data to create partitions. |
+
+---
+
+##### `fieldName`<sup>Optional</sup> <a name="fieldName" id="awscdk-resources-mongodbatlas.PartitionFields.property.fieldName"></a>
+
+```typescript
+public readonly fieldName: string;
+```
+
+- *Type:* string
+
+Human-readable label that identifies the field name used to partition data.
+
+---
+
+##### `order`<sup>Optional</sup> <a name="order" id="awscdk-resources-mongodbatlas.PartitionFields.property.order"></a>
+
+```typescript
+public readonly order: number;
+```
+
+- *Type:* number
+
+Sequence in which MongoDB Cloud slices the collection data to create partitions.
+
+The resource expresses this sequence starting with zero.
+
+---
+
 ### PartitionFieldView <a name="PartitionFieldView" id="awscdk-resources-mongodbatlas.PartitionFieldView"></a>
 
 #### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.PartitionFieldView.Initializer"></a>
@@ -39463,6 +41793,51 @@ public readonly roleNames: string[];
 List of roles to grant this API key.
 
 If you provide this list, provide a minimum of one role and ensure each role applies to this project.Items Enum: "ORG_OWNER" "ORG_MEMBER" "ORG_GROUP_CREATOR" "ORG_BILLING_ADMIN" "ORG_READ_ONLY" "ORG_TEAM_MEMBERS_ADMIN" "GROUP_ATLAS_ADMIN" "GROUP_AUTOMATION_ADMIN" "GROUP_BACKUP_ADMIN" "GROUP_MONITORING_ADMIN" "GROUP_OWNER" "GROUP_READ_ONLY" "GROUP_USER_ADMIN" "GROUP_BILLING_ADMIN" "GROUP_DATA_ACCESS_ADMIN" "GROUP_DATA_ACCESS_READ_ONLY" "GROUP_DATA_ACCESS_READ_WRITE" "GROUP_CHARTS_ADMIN" "GROUP_CLUSTER_MANAGER" "GROUP_SEARCH_INDEX_EDITOR"
+
+---
+
+### ProjectAssignment <a name="ProjectAssignment" id="awscdk-resources-mongodbatlas.ProjectAssignment"></a>
+
+#### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.ProjectAssignment.Initializer"></a>
+
+```typescript
+import { ProjectAssignment } from 'awscdk-resources-mongodbatlas'
+
+const projectAssignment: ProjectAssignment = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.ProjectAssignment.property.projectId">projectId</a></code> | <code>string</code> | Unique 24-hexadecimal digit string that identifies the project in an organization. |
+| <code><a href="#awscdk-resources-mongodbatlas.ProjectAssignment.property.roles">roles</a></code> | <code>string[]</code> | List of roles to grant this API key. |
+
+---
+
+##### `projectId`<sup>Optional</sup> <a name="projectId" id="awscdk-resources-mongodbatlas.ProjectAssignment.property.projectId"></a>
+
+```typescript
+public readonly projectId: string;
+```
+
+- *Type:* string
+
+Unique 24-hexadecimal digit string that identifies the project in an organization.
+
+---
+
+##### `roles`<sup>Optional</sup> <a name="roles" id="awscdk-resources-mongodbatlas.ProjectAssignment.property.roles"></a>
+
+```typescript
+public readonly roles: string[];
+```
+
+- *Type:* string[]
+
+List of roles to grant this API key.
+
+If you provide this list, provide a minimum of one role and ensure each role applies to this organization.
 
 ---
 
@@ -40448,6 +42823,161 @@ String Representing the AWS VPC ID (like: vpc-xxxxxxxxxxxxxxxx) (Used For Creati
 
 ---
 
+### Sink <a name="Sink" id="awscdk-resources-mongodbatlas.Sink"></a>
+
+Ingestion destination of a Data Lake Pipeline.
+
+#### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.Sink.Initializer"></a>
+
+```typescript
+import { Sink } from 'awscdk-resources-mongodbatlas'
+
+const sink: Sink = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.Sink.property.metadataProvider">metadataProvider</a></code> | <code>string</code> | Target cloud provider for this Data Lake Pipeline. |
+| <code><a href="#awscdk-resources-mongodbatlas.Sink.property.metadataRegion">metadataRegion</a></code> | <code>string</code> | Target cloud provider region for this Data Lake Pipeline. |
+| <code><a href="#awscdk-resources-mongodbatlas.Sink.property.partitionFields">partitionFields</a></code> | <code><a href="#awscdk-resources-mongodbatlas.PartitionFields">PartitionFields</a>[]</code> | Ordered fields used to physically organize data in the destination. |
+| <code><a href="#awscdk-resources-mongodbatlas.Sink.property.type">type</a></code> | <code><a href="#awscdk-resources-mongodbatlas.SinkType">SinkType</a></code> | Type of ingestion destination of this Data Lake Pipeline. |
+
+---
+
+##### `metadataProvider`<sup>Optional</sup> <a name="metadataProvider" id="awscdk-resources-mongodbatlas.Sink.property.metadataProvider"></a>
+
+```typescript
+public readonly metadataProvider: string;
+```
+
+- *Type:* string
+
+Target cloud provider for this Data Lake Pipeline.
+
+---
+
+##### `metadataRegion`<sup>Optional</sup> <a name="metadataRegion" id="awscdk-resources-mongodbatlas.Sink.property.metadataRegion"></a>
+
+```typescript
+public readonly metadataRegion: string;
+```
+
+- *Type:* string
+
+Target cloud provider region for this Data Lake Pipeline.
+
+---
+
+##### `partitionFields`<sup>Optional</sup> <a name="partitionFields" id="awscdk-resources-mongodbatlas.Sink.property.partitionFields"></a>
+
+```typescript
+public readonly partitionFields: PartitionFields[];
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.PartitionFields">PartitionFields</a>[]
+
+Ordered fields used to physically organize data in the destination.
+
+---
+
+##### `type`<sup>Optional</sup> <a name="type" id="awscdk-resources-mongodbatlas.Sink.property.type"></a>
+
+```typescript
+public readonly type: SinkType;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.SinkType">SinkType</a>
+
+Type of ingestion destination of this Data Lake Pipeline.
+
+---
+
+### Source <a name="Source" id="awscdk-resources-mongodbatlas.Source"></a>
+
+Ingestion destination of a Data Lake Pipeline.
+
+#### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.Source.Initializer"></a>
+
+```typescript
+import { Source } from 'awscdk-resources-mongodbatlas'
+
+const source: Source = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.Source.property.clusterName">clusterName</a></code> | <code>string</code> | Human-readable name that identifies the cluster. |
+| <code><a href="#awscdk-resources-mongodbatlas.Source.property.collectionName">collectionName</a></code> | <code>string</code> | Human-readable name that identifies the collection. |
+| <code><a href="#awscdk-resources-mongodbatlas.Source.property.databaseName">databaseName</a></code> | <code>string</code> | Human-readable name that identifies the database. |
+| <code><a href="#awscdk-resources-mongodbatlas.Source.property.groupId">groupId</a></code> | <code>string</code> | Unique 24-hexadecimal character string that identifies the project. |
+| <code><a href="#awscdk-resources-mongodbatlas.Source.property.type">type</a></code> | <code><a href="#awscdk-resources-mongodbatlas.SourceType">SourceType</a></code> | Type of ingestion source of this Data Lake Pipeline. |
+
+---
+
+##### `clusterName`<sup>Optional</sup> <a name="clusterName" id="awscdk-resources-mongodbatlas.Source.property.clusterName"></a>
+
+```typescript
+public readonly clusterName: string;
+```
+
+- *Type:* string
+
+Human-readable name that identifies the cluster.
+
+---
+
+##### `collectionName`<sup>Optional</sup> <a name="collectionName" id="awscdk-resources-mongodbatlas.Source.property.collectionName"></a>
+
+```typescript
+public readonly collectionName: string;
+```
+
+- *Type:* string
+
+Human-readable name that identifies the collection.
+
+---
+
+##### `databaseName`<sup>Optional</sup> <a name="databaseName" id="awscdk-resources-mongodbatlas.Source.property.databaseName"></a>
+
+```typescript
+public readonly databaseName: string;
+```
+
+- *Type:* string
+
+Human-readable name that identifies the database.
+
+---
+
+##### `groupId`<sup>Optional</sup> <a name="groupId" id="awscdk-resources-mongodbatlas.Source.property.groupId"></a>
+
+```typescript
+public readonly groupId: string;
+```
+
+- *Type:* string
+
+Unique 24-hexadecimal character string that identifies the project.
+
+---
+
+##### `type`<sup>Optional</sup> <a name="type" id="awscdk-resources-mongodbatlas.Source.property.type"></a>
+
+```typescript
+public readonly type: SourceType;
+```
+
+- *Type:* <a href="#awscdk-resources-mongodbatlas.SourceType">SourceType</a>
+
+Type of ingestion source of this Data Lake Pipeline.
+
+---
+
 ### Specs <a name="Specs" id="awscdk-resources-mongodbatlas.Specs"></a>
 
 #### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.Specs.Initializer"></a>
@@ -41008,6 +43538,51 @@ public readonly profile: string;
 - *Type:* string
 
 Atlas API keys.
+
+---
+
+### Transformations <a name="Transformations" id="awscdk-resources-mongodbatlas.Transformations"></a>
+
+Ordered fields used to physically organize data in the destination.
+
+#### Initializer <a name="Initializer" id="awscdk-resources-mongodbatlas.Transformations.Initializer"></a>
+
+```typescript
+import { Transformations } from 'awscdk-resources-mongodbatlas'
+
+const transformations: Transformations = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.Transformations.property.field">field</a></code> | <code>string</code> | Key in the document. |
+| <code><a href="#awscdk-resources-mongodbatlas.Transformations.property.type">type</a></code> | <code>string</code> | Type of transformation applied during the export of the namespace in a Data Lake Pipeline. |
+
+---
+
+##### `field`<sup>Optional</sup> <a name="field" id="awscdk-resources-mongodbatlas.Transformations.property.field"></a>
+
+```typescript
+public readonly field: string;
+```
+
+- *Type:* string
+
+Key in the document.
+
+---
+
+##### `type`<sup>Optional</sup> <a name="type" id="awscdk-resources-mongodbatlas.Transformations.property.type"></a>
+
+```typescript
+public readonly type: string;
+```
+
+- *Type:* string
+
+Type of transformation applied during the export of the namespace in a Data Lake Pipeline.
 
 ---
 
@@ -43546,6 +46121,52 @@ Human-readable label that identifies the cloud service provider.
 ##### `SERVERLESS` <a name="SERVERLESS" id="awscdk-resources-mongodbatlas.ServerlessInstanceProviderSettingsProviderName.SERVERLESS"></a>
 
 SERVERLESS.
+
+---
+
+
+### SinkType <a name="SinkType" id="awscdk-resources-mongodbatlas.SinkType"></a>
+
+Type of ingestion destination of this Data Lake Pipeline.
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.SinkType.DLS">DLS</a></code> | DLS. |
+
+---
+
+##### `DLS` <a name="DLS" id="awscdk-resources-mongodbatlas.SinkType.DLS"></a>
+
+DLS.
+
+---
+
+
+### SourceType <a name="SourceType" id="awscdk-resources-mongodbatlas.SourceType"></a>
+
+Type of ingestion source of this Data Lake Pipeline.
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.SourceType.ON_DEMAND_CPS">ON_DEMAND_CPS</a></code> | ON_DEMAND_CPS. |
+| <code><a href="#awscdk-resources-mongodbatlas.SourceType.PERIODIC_CPS">PERIODIC_CPS</a></code> | PERIODIC_CPS. |
+
+---
+
+##### `ON_DEMAND_CPS` <a name="ON_DEMAND_CPS" id="awscdk-resources-mongodbatlas.SourceType.ON_DEMAND_CPS"></a>
+
+ON_DEMAND_CPS.
+
+---
+
+
+##### `PERIODIC_CPS` <a name="PERIODIC_CPS" id="awscdk-resources-mongodbatlas.SourceType.PERIODIC_CPS"></a>
+
+PERIODIC_CPS.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@
 
 // L1 Constructors
 
-export { CfnAccessListApiKey, CfnAccessListApiKeyProps } from "./l1-resources/access-list-api-key";
+export {
+  CfnAccessListApiKey,
+  CfnAccessListApiKeyProps,
+} from "./l1-resources/access-list-api-key";
 
 export {
   CfnAlertConfiguration,
@@ -35,35 +38,13 @@ export {
   NotificationViewSeverity,
 } from "./l1-resources/alert-configuration";
 
-export { CfnApiKey, CfnApiKeyProps } from "./l1-resources/api-key";
+export {
+  CfnApiKey,
+  CfnApiKeyProps,
+  ProjectAssignment,
+} from "./l1-resources/api-key";
 
 export { CfnAuditing, CfnAuditingProps } from "./l1-resources/auditing";
-
-export {
-  CfnFederatedQueryLimit,
-  CfnFederatedQueryLimitProps,
-  CfnFederatedQueryLimitPropsLimitName,
-} from "./l1-resources/federated-query-limit";
-
-export {
-  CfnFederatedDatabaseInstance,
-  CfnFederatedDatabaseInstanceProps,
-  CloudProviderConfig,
-  DataProcessRegion,
-  Storage,
-  Database,
-  Store,
-  Collection,
-  DataSource,
-  ReadPreference,
-  TagSet,
-  View,
-} from "./l1-resources/federated-database-instance";
-
-export {
-  CfnPrivatelinkEndpointServiceDataFederationOnlineArchive,
-  CfnPrivatelinkEndpointServiceDataFederationOnlineArchiveProps,
-} from "./l1-resources/privatelink-endpoint-service-data-federation-online-archive";
 
 export {
   CfnCloudBackUpRestoreJobs,
@@ -142,8 +123,16 @@ export {
   CfnCustomDnsConfigurationClusterAwsProps,
 } from "./l1-resources/custom-dns-configuration-cluster-aws";
 
-
-export { CfnDataLakePipeline, CfnDataLakePipelineProps } from "./l1-resources/data-lake-pipeline";
+export {
+  CfnDataLakePipeline,
+  CfnDataLakePipelineProps,
+  Sink,
+  SinkType,
+  Source,
+  SourceType,
+  Transformations,
+  PartitionFields,
+} from "./l1-resources/data-lake-pipeline";
 
 export {
   CfnDatabaseUser,
@@ -179,6 +168,27 @@ export {
   CfnEncryptionAtRest,
   CfnEncryptionAtRestProps,
 } from "./l1-resources/encryption-at-rest";
+
+export {
+  CfnFederatedDatabaseInstance,
+  CfnFederatedDatabaseInstanceProps,
+  CloudProviderConfig,
+  DataProcessRegion,
+  Storage,
+  Database,
+  Store,
+  Collection,
+  DataSource,
+  ReadPreference,
+  TagSet,
+  View,
+} from "./l1-resources/federated-database-instance";
+
+export {
+  CfnFederatedQueryLimit,
+  CfnFederatedQueryLimitProps,
+  CfnFederatedQueryLimitPropsLimitName,
+} from "./l1-resources/federated-query-limit";
 
 export {
   CfnFederatedSettingsOrgRoleMapping,
@@ -221,6 +231,19 @@ export {
 } from "./l1-resources/network-peering";
 
 export {
+  CfnOnlineArchive,
+  CfnOnlineArchiveProps,
+  CfnOnlineArchivePropsCollectionType,
+  CriteriaView,
+  CriteriaViewDateFormat,
+  CriteriaViewType,
+  PartitionFieldView,
+  PartitionFieldViewFieldType,
+  ScheduleView,
+  ScheduleViewType,
+} from "./l1-resources/online-archive";
+
+export {
   CfnOrgInvitation,
   CfnOrgInvitationProps,
   CfnOrgInvitationPropsRoles,
@@ -239,9 +262,19 @@ export {
 } from "./l1-resources/private-endpoint";
 
 export {
+  CfnPrivateEndpointAdl,
+  CfnPrivateEndpointAdlProps,
+} from "./l1-resources/private-endpoint-adl";
+
+export {
   CfnPrivateEndpointAwsProps,
   CfnPrivateEndpointAws,
 } from "./l1-resources/private-endpoint-aws";
+
+export {
+  CfnPrivateEndPointRegionalMode,
+  CfnPrivateEndPointRegionalModeProps,
+} from "./l1-resources/private-endpoint-regional-mode";
 
 export {
   CfnPrivateEndpointService,
@@ -250,21 +283,9 @@ export {
 } from "./l1-resources/private-endpoint-service";
 
 export {
-  CfnServerlessPrivateEndpointProps,
-  CfnServerlessPrivateEndpoint,
-  ServerlessPrivateEndpoint,
-  AwsPrivateEndpointConfig,
-} from "./l1-resources/serverless-private-endpoint";
-
-export {
-  CfnPrivateEndpointAdl,
-  CfnPrivateEndpointAdlProps,
-} from "./l1-resources/private-endpoint-adl";
-
-export {
-  CfnPrivateEndPointRegionalMode,
-  CfnPrivateEndPointRegionalModeProps,
-} from "./l1-resources/private-endpoint-regional-mode";
+  CfnPrivatelinkEndpointServiceDataFederationOnlineArchive,
+  CfnPrivatelinkEndpointServiceDataFederationOnlineArchiveProps,
+} from "./l1-resources/privatelink-endpoint-service-data-federation-online-archive";
 
 export {
   CfnProject,
@@ -308,6 +329,13 @@ export {
 } from "./l1-resources/serverless-instance";
 
 export {
+  CfnServerlessPrivateEndpointProps,
+  CfnServerlessPrivateEndpoint,
+  ServerlessPrivateEndpoint,
+  AwsPrivateEndpointConfig,
+} from "./l1-resources/serverless-private-endpoint";
+
+export {
   CfnTeams,
   CfnTeamsProps,
   CfnTeamsPropsRoleNames,
@@ -315,6 +343,14 @@ export {
   AtlasRole,
   AtlasUser,
 } from "./l1-resources/teams";
+
+export {
+  CfnThirdPartyIntegration,
+  CfnThirdPartyIntegrationProps,
+  CfnThirdPartyIntegrationPropsScheme,
+  CfnThirdPartyIntegrationPropsServiceDiscovery,
+  CfnThirdPartyIntegrationPropsType,
+} from "./l1-resources/third-party-integration";
 
 export {
   AuthConfig,
@@ -333,41 +369,22 @@ export {
 } from "./l1-resources/trigger";
 
 export {
-  CfnThirdPartyIntegration,
-  CfnThirdPartyIntegrationProps,
-  CfnThirdPartyIntegrationPropsScheme,
-  CfnThirdPartyIntegrationPropsServiceDiscovery,
-  CfnThirdPartyIntegrationPropsType,
-} from "./l1-resources/third-party-integration";
-
-export {
   CfnX509AuthenticationDatabaseUser,
   CfnX509AuthenticationDatabaseUserProps,
   CustomerX509,
 } from "./l1-resources/x509-authentication-database-user";
 
-export {
-  CfnOnlineArchive,
-  CfnOnlineArchiveProps,
-  CfnOnlineArchivePropsCollectionType,
-  CriteriaView,
-  CriteriaViewDateFormat,
-  CriteriaViewType,
-  PartitionFieldView,
-  PartitionFieldViewFieldType,
-  ScheduleView,
-  ScheduleViewType,
-} from "./l1-resources/online-archive";
-
 // L2 Constructors
+
 export * from "./l2-resources/encryption-at-rest";
 export * from "./l2-resources/third-party-integration";
 
 // L3 Constructors
+
+export * from "./l3-resources/common/props";
+
 export * from "./l3-resources/atlas-basic";
 export * from "./l3-resources/atlas-serverless-basic";
 export * from "./l3-resources/atlas-basic-private-endpoint";
 export * from "./l3-resources/encryption-at-rest-express";
 export * from "./l3-resources/atlas-bootstrap";
-
-export * from "./l3-resources/common/props";

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ export {
   NotificationViewSeverity,
 } from "./l1-resources/alert-configuration";
 
+export { CfnApiKey, CfnApiKeyProps } from "./l1-resources/api-key";
+
 export { CfnAuditing, CfnAuditingProps } from "./l1-resources/auditing";
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,9 @@ export {
   CfnCustomDnsConfigurationClusterAwsProps,
 } from "./l1-resources/custom-dns-configuration-cluster-aws";
 
+
+export { CfnDataLakePipeline, CfnDataLakePipelineProps } from "./l1-resources/data-lake-pipeline";
+
 export {
   CfnDatabaseUser,
   CfnDatabaseUserProps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 // L1 Constructors
+
+export { CfnAccessListApiKey, CfnAccessListApiKeyProps } from "./l1-resources/access-list-api-key";
+
 export {
   CfnAlertConfiguration,
   CfnAlertConfigurationProps,

--- a/test/l1-resources/access-list-api-key/index.test.ts
+++ b/test/l1-resources/access-list-api-key/index.test.ts
@@ -1,9 +1,6 @@
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import {
-  CfnAccessListApiKey,
-  CfnAccessListApiKeyProps,
-} from "../../../src/l1-resources/access-list-api-key";
+import { CfnAccessListApiKey, CfnAccessListApiKeyProps } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::AccessListAPIKey";
 const ORG_ID = "63350255419cf25e3d511c95";

--- a/test/l1-resources/api-key/index.test.ts
+++ b/test/l1-resources/api-key/index.test.ts
@@ -6,7 +6,7 @@ import {
   CfnApiKeyProps,
   ProjectAssignment,
   ListOptions,
-} from "../../../src/l1-resources/api-key";
+} from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::APIKey";
 const ORG_ID = "63350255419cf25e3d511c95";

--- a/test/l1-resources/cloud-backup-restore-jobs/index.test.ts
+++ b/test/l1-resources/cloud-backup-restore-jobs/index.test.ts
@@ -18,7 +18,7 @@ import {
   CfnCloudBackUpRestoreJobs,
   CfnCloudBackUpRestoreJobsPropsDeliveryType,
   CfnCloudBackUpRestoreJobsPropsInstanceType,
-} from "../../../src/l1-resources/cloud-backup-restore-jobs";
+} from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::CloudBackUpRestoreJobs";
 const CLUSTER_NAME = "testCluster";

--- a/test/l1-resources/cloud-backup-schedule/index.test.ts
+++ b/test/l1-resources/cloud-backup-schedule/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnCloudBackupSchedule } from "../../../src/l1-resources/cloud-backup-schedule";
+import { CfnCloudBackupSchedule } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::CloudBackupSchedule";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/cloud-backup-snapshot/index.test.ts
+++ b/test/l1-resources/cloud-backup-snapshot/index.test.ts
@@ -17,7 +17,7 @@ import { Template } from "aws-cdk-lib/assertions";
 import {
   CfnCloudBackupSnapshot,
   CfnCloudBackupSnapshotPropsInstanceType,
-} from "../../../src/l1-resources/cloud-backup-snapshot";
+} from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::CloudBackupSnapshot";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/cluster-outage-simulation/index.test.ts
+++ b/test/l1-resources/cluster-outage-simulation/index.test.ts
@@ -14,10 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import {
-  CfnClusterOutageSimulation,
-  FilterCloudProvider,
-} from "../../../src/l1-resources/cluster-outage-simulation";
+import { CfnClusterOutageSimulation, FilterCloudProvider } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::ClusterOutageSimulation";
 const PROJECTI_ID = "test_project_id";

--- a/test/l1-resources/clusters/index.test.ts
+++ b/test/l1-resources/clusters/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnCluster } from "../../../src/l1-resources/clusters";
+import { CfnCluster } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::Cluster";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/data-lake-pipeline/index.test.ts
+++ b/test/l1-resources/data-lake-pipeline/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnDataLakePipeline } from "../../../src/l1-resources/data-lake-pipeline";
+import { CfnDataLakePipeline } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::DataLakePipeline";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/encryption-at-rest/index.test.ts
+++ b/test/l1-resources/encryption-at-rest/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnEncryptionAtRest } from "../../../src/l1-resources/encryption-at-rest";
+import { CfnEncryptionAtRest } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::EncryptionAtRest";
 const PROFILE = "default";

--- a/test/l1-resources/federated-database-instance/index.test.ts
+++ b/test/l1-resources/federated-database-instance/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnFederatedDatabaseInstance } from "../../../src/l1-resources/federated-database-instance";
+import { CfnFederatedDatabaseInstance } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::FederatedDatabaseInstance";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/federated-query-limit/index.test.ts
+++ b/test/l1-resources/federated-query-limit/index.test.ts
@@ -18,7 +18,7 @@ import {
   CfnFederatedQueryLimit,
   CfnFederatedQueryLimitProps,
   CfnFederatedQueryLimitPropsLimitName,
-} from "../../../src/l1-resources/federated-query-limit";
+} from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::FederatedQueryLimit";
 const PROJECT_ID = "64bad960538ae76ec5c70050";

--- a/test/l1-resources/federated-settings-org-role-mapping/index.test.ts
+++ b/test/l1-resources/federated-settings-org-role-mapping/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnFederatedSettingsOrgRoleMapping } from "../../../src/l1-resources/federated-settings-org-role-mapping";
+import { CfnFederatedSettingsOrgRoleMapping } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::FederatedSettingsOrgRoleMapping";
 const PROJECT_ID = "97498392039231";

--- a/test/l1-resources/global-cluster-config/index.test.ts
+++ b/test/l1-resources/global-cluster-config/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnGlobalClusterConfig } from "../../../src/l1-resources/global-cluster-config";
+import { CfnGlobalClusterConfig } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::GlobalClusterConfig";
 const PROFILE = "default";

--- a/test/l1-resources/ldap-configuration/index.test.ts
+++ b/test/l1-resources/ldap-configuration/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnLdapConfiguration } from "../../../src/l1-resources/ldap-configuration";
+import { CfnLdapConfiguration } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::LDAPConfiguration";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/ldap-verify/index.test.ts
+++ b/test/l1-resources/ldap-verify/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnLdapVerify } from "../../../src/l1-resources/ldap-verify";
+import { CfnLdapVerify } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::LDAPVerify";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/organization/index.test.ts
+++ b/test/l1-resources/organization/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnOrganization } from "../../../src/l1-resources/organization";
+import { CfnOrganization } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::Organization";
 const NAME = "testProjectId";

--- a/test/l1-resources/private-endpoint-adl/index.test.ts
+++ b/test/l1-resources/private-endpoint-adl/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnPrivateEndpointAdl } from "../../../src/l1-resources/private-endpoint-adl";
+import { CfnPrivateEndpointAdl } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::PrivateEndpointADL";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/private-endpoint-aws/index.test.ts
+++ b/test/l1-resources/private-endpoint-aws/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnPrivateEndpointAws } from "../../../src/l1-resources/private-endpoint-aws";
+import { CfnPrivateEndpointAws } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::PrivateEndpointAWS";
 const ENDPOINT_SERVICE_ID = "testendpointserviceId";

--- a/test/l1-resources/private-endpoint-regional-mode/index.test.ts
+++ b/test/l1-resources/private-endpoint-regional-mode/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnPrivateEndPointRegionalMode } from "../../../src/l1-resources/private-endpoint-regional-mode";
+import { CfnPrivateEndPointRegionalMode } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::PrivateEndPointRegionalMode";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/private-endpoint-service/index.test.ts
+++ b/test/l1-resources/private-endpoint-service/index.test.ts
@@ -17,7 +17,7 @@ import { Template } from "aws-cdk-lib/assertions";
 import {
   CfnPrivateEndpointService,
   CfnPrivateEndpointServicePropsCloudProvider,
-} from "../../../src/l1-resources/private-endpoint-service";
+} from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::PrivateEndpointService";
 const REGION = "US_EAST_1";

--- a/test/l1-resources/privatelink-endpoint-service-data-federation-online-archive/index.test.ts
+++ b/test/l1-resources/privatelink-endpoint-service-data-federation-online-archive/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnPrivatelinkEndpointServiceDataFederationOnlineArchive } from "../../../src/l1-resources/privatelink-endpoint-service-data-federation-online-archive";
+import { CfnPrivatelinkEndpointServiceDataFederationOnlineArchive } from "../../../src";
 
 const RESOURCE_NAME =
   "MongoDB::Atlas::PrivatelinkEndpointServiceDataFederationOnlineArchive";

--- a/test/l1-resources/project-invitation/index.test.ts
+++ b/test/l1-resources/project-invitation/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnProjectInvitation } from "../../../src/l1-resources/project-invitation";
+import { CfnProjectInvitation } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::ProjectInvitation";
 const PROFILE = "default";

--- a/test/l1-resources/project/index.test.ts
+++ b/test/l1-resources/project/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnProject } from "../../../src/l1-resources/project";
+import { CfnProject } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::Project";
 const PROJECT_ID = "63350255419cf25e3d511c95";

--- a/test/l1-resources/search-index/index.test.ts
+++ b/test/l1-resources/search-index/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnSearchIndex } from "../../../src/l1-resources/search-index";
+import { CfnSearchIndex } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::SearchIndex";
 const PROJECT_ID = "projectId";

--- a/test/l1-resources/serverless-instance/index.test.ts
+++ b/test/l1-resources/serverless-instance/index.test.ts
@@ -17,7 +17,7 @@ import { Template } from "aws-cdk-lib/assertions";
 import {
   CfnServerlessInstance,
   ServerlessInstanceProviderSettingsProviderName,
-} from "../../../src/l1-resources/serverless-instance";
+} from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::ServerlessInstance";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/serverless-private-endpoint/index.test.ts
+++ b/test/l1-resources/serverless-private-endpoint/index.test.ts
@@ -3,7 +3,7 @@ import { Template } from "aws-cdk-lib/assertions";
 import {
   CfnServerlessPrivateEndpoint,
   AwsPrivateEndpointConfig,
-} from "../../../src/l1-resources/serverless-private-endpoint";
+} from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::ServerlessPrivateEndpoint";
 const INSTANCE_NAME = "testserverlessprivateendpoint";

--- a/test/l1-resources/teams/index.test.ts
+++ b/test/l1-resources/teams/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnTeams } from "../../../src/l1-resources/teams";
+import { CfnTeams } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::Teams";
 const PROFILE = "default";

--- a/test/l1-resources/trigger/index.test.ts
+++ b/test/l1-resources/trigger/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnTrigger } from "../../../src/l1-resources/trigger";
+import { CfnTrigger } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::Trigger";
 const PROJECT_ID = "testProjectId";

--- a/test/l1-resources/x509-authentication-database-user/index.test.ts
+++ b/test/l1-resources/x509-authentication-database-user/index.test.ts
@@ -14,7 +14,7 @@
 
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { CfnX509AuthenticationDatabaseUser } from "../../../src/l1-resources/x509-authentication-database-user";
+import { CfnX509AuthenticationDatabaseUser } from "../../../src";
 
 const RESOURCE_NAME = "MongoDB::Atlas::X509AuthenticationDatabaseUser";
 const PROJECT_ID = "testProjectId";


### PR DESCRIPTION
## Proposed changes

Fixes export visibility for access-list-api-key, api-key and data-lake-pipeline.

Sorts export resources in alphabetical order so it's easier to see if some resource is missing in exports.

Improves L1 tests by only using exported objects.


_Jira ticket:_ CLOUDP-234406


Link to any related issue(s): https://github.com/mongodb/awscdk-resources-mongodbatlas/issues/223


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code
- [X] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
