### PR TITLE
chore: Updates node version to 18 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 16.14.0
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 16.14.0
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
@@ -93,7 +93,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 16.14.0
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 16.14.0
+          node-version: 18.x
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: 3.x
@@ -185,7 +185,7 @@ jobs:
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 16.14.0
+          node-version: 18.x
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3
         with:
           dotnet-version: 3.x
@@ -230,7 +230,7 @@ jobs:
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 16.14.0
+          node-version: 18.x
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ^1.16.0
@@ -277,7 +277,7 @@ jobs:
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 16.14.0
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:


### PR DESCRIPTION
## Proposed changes

Fix is made after encountering failure in publish workflow: https://github.com/mongodb/awscdk-resources-mongodbatlas/actions/runs/8245838177

Node version aligns with version used for our CI checks which are working: https://github.com/mongodb/awscdk-resources-mongodbatlas/blob/main/.github/workflows/code-health.yml#L23

**Side note:** There is still a old typescript version defined in [package.json dev dependencies](https://github.com/mongodb/awscdk-resources-mongodbatlas/blob/main/package.json#L43), which is being automatically defined by projen in [.projen/deps.json](https://github.com/mongodb/awscdk-resources-mongodbatlas/blob/main/.projen/deps.json#L10). We have to further investigate how this version can be updated as well, but is not a blocker for fixing the release process.
<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
