### PR TITLE
remove: typeName from CfnAlertConfigurationProps

### DIFF
--- a/src/l1-resources/alert-configuration/index.ts
+++ b/src/l1-resources/alert-configuration/index.ts
@@ -63,13 +63,6 @@ export interface CfnAlertConfigurationProps {
    * @schema CfnAlertConfigurationProps#Threshold
    */
   readonly threshold?: IntegerThresholdView;
-
-  /**
-   * Human-readable label that displays the alert type.
-   *
-   * @schema CfnAlertConfigurationProps#TypeName
-   */
-  readonly typeName?: string;
 }
 
 /**
@@ -91,7 +84,6 @@ export function toJson_CfnAlertConfigurationProps(
     MetricThreshold: toJson_MetricThresholdView(obj.metricThreshold),
     Notifications: obj.notifications?.map((y) => toJson_NotificationView(y)),
     Threshold: toJson_IntegerThresholdView(obj.threshold),
-    TypeName: obj.typeName,
   };
   // filter undefined values
   return Object.entries(result).reduce(


### PR DESCRIPTION
## Proposed changes

Remove the `CfnAlertConfigurationProps.typeName` property. It is not mentioned in the [createAlertConfiguration rest API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/createAlertConfiguration) and not forwarded by the corresponding [CloudFormation resource](https://github.com/mongodb/mongodbatlas-cloudformation-resources/blob/master/cfn-resources/alert-configuration/cmd/resource/resource.go#L82).

Unfortunately, this would be a breaking change. Maybe the property should be deprecated first and removed later.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
