### PR TITLE
fix: Allows not setting optional attributes DataProcessRegion and CloudProviderConfig for FederatedDatabaseInstance

### DIFF
--- a/API.md
+++ b/API.md
@@ -11900,7 +11900,10 @@ Check whether the given construct is a CfnResource.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.ref">ref</a></code> | <code>string</code> | Return a string that will be resolved to a CloudFormation `{ Ref }` for this element. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.cfnOptions">cfnOptions</a></code> | <code>aws-cdk-lib.ICfnResourceOptions</code> | Options for this resource, such as condition, update policy etc. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.cfnResourceType">cfnResourceType</a></code> | <code>string</code> | AWS resource type. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrExternalId">attrExternalId</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.ExternalId`. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrHostNames">attrHostNames</a></code> | <code>string[]</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.HostNames`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrIamAssumedRoleARNN">attrIamAssumedRoleARNN</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamAssumedRoleARN`. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrIamUserARN">attrIamUserARN</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamUserARN`. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrState">attrState</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.State`. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.props">props</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstanceProps">CfnFederatedDatabaseInstanceProps</a></code> | Resource props. |
 
@@ -11998,6 +12001,18 @@ AWS resource type.
 
 ---
 
+##### `attrExternalId`<sup>Required</sup> <a name="attrExternalId" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrExternalId"></a>
+
+```typescript
+public readonly attrExternalId: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.ExternalId`.
+
+---
+
 ##### `attrHostNames`<sup>Required</sup> <a name="attrHostNames" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrHostNames"></a>
 
 ```typescript
@@ -12007,6 +12022,30 @@ public readonly attrHostNames: string[];
 - *Type:* string[]
 
 Attribute `MongoDB::Atlas::FederatedDatabaseInstance.HostNames`.
+
+---
+
+##### `attrIamAssumedRoleARNN`<sup>Required</sup> <a name="attrIamAssumedRoleARNN" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrIamAssumedRoleARNN"></a>
+
+```typescript
+public readonly attrIamAssumedRoleARNN: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamAssumedRoleARN`.
+
+---
+
+##### `attrIamUserARN`<sup>Required</sup> <a name="attrIamUserARN" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrIamUserARN"></a>
+
+```typescript
+public readonly attrIamUserARN: string;
+```
+
+- *Type:* string
+
+Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamUserARN`.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -11900,10 +11900,7 @@ Check whether the given construct is a CfnResource.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.ref">ref</a></code> | <code>string</code> | Return a string that will be resolved to a CloudFormation `{ Ref }` for this element. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.cfnOptions">cfnOptions</a></code> | <code>aws-cdk-lib.ICfnResourceOptions</code> | Options for this resource, such as condition, update policy etc. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.cfnResourceType">cfnResourceType</a></code> | <code>string</code> | AWS resource type. |
-| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrExternalId">attrExternalId</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.ExternalId`. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrHostNames">attrHostNames</a></code> | <code>string[]</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.HostNames`. |
-| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrIamAssumedRoleARNN">attrIamAssumedRoleARNN</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamAssumedRoleARN`. |
-| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrIamUserARN">attrIamUserARN</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamUserARN`. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrState">attrState</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::FederatedDatabaseInstance.State`. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.props">props</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstanceProps">CfnFederatedDatabaseInstanceProps</a></code> | Resource props. |
 
@@ -12001,18 +11998,6 @@ AWS resource type.
 
 ---
 
-##### `attrExternalId`<sup>Required</sup> <a name="attrExternalId" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrExternalId"></a>
-
-```typescript
-public readonly attrExternalId: string;
-```
-
-- *Type:* string
-
-Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.ExternalId`.
-
----
-
 ##### `attrHostNames`<sup>Required</sup> <a name="attrHostNames" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrHostNames"></a>
 
 ```typescript
@@ -12022,30 +12007,6 @@ public readonly attrHostNames: string[];
 - *Type:* string[]
 
 Attribute `MongoDB::Atlas::FederatedDatabaseInstance.HostNames`.
-
----
-
-##### `attrIamAssumedRoleARNN`<sup>Required</sup> <a name="attrIamAssumedRoleARNN" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrIamAssumedRoleARNN"></a>
-
-```typescript
-public readonly attrIamAssumedRoleARNN: string;
-```
-
-- *Type:* string
-
-Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamAssumedRoleARN`.
-
----
-
-##### `attrIamUserARN`<sup>Required</sup> <a name="attrIamUserARN" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.property.attrIamUserARN"></a>
-
-```typescript
-public readonly attrIamUserARN: string;
-```
-
-- *Type:* string
-
-Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamUserARN`.
 
 ---
 
@@ -41947,8 +41908,20 @@ const dataProcessRegion: DataProcessRegion = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#awscdk-resources-mongodbatlas.DataProcessRegion.property.cloudProvider">cloudProvider</a></code> | <code>string</code> | Name of the cloud service that hosts the data lake's data stores. |
 | <code><a href="#awscdk-resources-mongodbatlas.DataProcessRegion.property.region">region</a></code> | <code>string</code> | Name of the region to which the data lake routes client connections. |
+| <code><a href="#awscdk-resources-mongodbatlas.DataProcessRegion.property.cloudProvider">cloudProvider</a></code> | <code>string</code> | Name of the cloud service that hosts the data lake's data stores. |
+
+---
+
+##### `region`<sup>Required</sup> <a name="region" id="awscdk-resources-mongodbatlas.DataProcessRegion.property.region"></a>
+
+```typescript
+public readonly region: string;
+```
+
+- *Type:* string
+
+Name of the region to which the data lake routes client connections.
 
 ---
 
@@ -41961,18 +41934,6 @@ public readonly cloudProvider: string;
 - *Type:* string
 
 Name of the cloud service that hosts the data lake's data stores.
-
----
-
-##### `region`<sup>Optional</sup> <a name="region" id="awscdk-resources-mongodbatlas.DataProcessRegion.property.region"></a>
-
-```typescript
-public readonly region: string;
-```
-
-- *Type:* string
-
-Name of the region to which the data lake routes client connections.
 
 ---
 

--- a/src/l1-resources/federated-database-instance/index.ts
+++ b/src/l1-resources/federated-database-instance/index.ts
@@ -170,7 +170,7 @@ export interface DataProcessRegion {
    *
    * @schema DataProcessRegion#Region
    */
-  readonly region?: string;
+  readonly region: string;
 }
 
 /**
@@ -676,21 +676,6 @@ export class CfnFederatedDatabaseInstance extends cdk.CfnResource {
   public readonly attrState: string;
 
   /**
-   * Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.ExternalId`
-   */
-  public readonly attrExternalId: string;
-
-  /**
-   * Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamAssumedRoleARN`
-   */
-  public readonly attrIamAssumedRoleARNN: string;
-
-  /**
-   * Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamUserARN`
-   */
-  public readonly attrIamUserARN: string;
-
-  /**
    * Create a new `MongoDB::Atlas::FederatedDatabaseInstance`.
    *
    * @param scope - scope in which this resource is defined
@@ -711,14 +696,5 @@ export class CfnFederatedDatabaseInstance extends cdk.CfnResource {
 
     this.attrHostNames = cdk.Token.asList(this.getAtt("HostNames"));
     this.attrState = cdk.Token.asString(this.getAtt("State"));
-    this.attrExternalId = cdk.Token.asString(
-      this.getAtt("CloudProviderConfig.ExternalId")
-    );
-    this.attrIamUserARN = cdk.Token.asString(
-      this.getAtt("CloudProviderConfig.IamUserARN")
-    );
-    this.attrIamAssumedRoleARNN = cdk.Token.asString(
-      this.getAtt("CloudProviderConfig.IamAssumedRoleARN")
-    );
   }
 }

--- a/src/l1-resources/federated-database-instance/index.ts
+++ b/src/l1-resources/federated-database-instance/index.ts
@@ -676,6 +676,21 @@ export class CfnFederatedDatabaseInstance extends cdk.CfnResource {
   public readonly attrState: string;
 
   /**
+   * Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.ExternalId`
+   */
+  public readonly attrExternalId: string;
+
+  /**
+   * Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamAssumedRoleARN`
+   */
+  public readonly attrIamAssumedRoleARNN: string;
+
+  /**
+   * Attribute `MongoDB::Atlas::FederatedDatabaseInstance.CloudProviderConfig.IamUserARN`
+   */
+  public readonly attrIamUserARN: string;
+
+  /**
    * Create a new `MongoDB::Atlas::FederatedDatabaseInstance`.
    *
    * @param scope - scope in which this resource is defined
@@ -696,5 +711,14 @@ export class CfnFederatedDatabaseInstance extends cdk.CfnResource {
 
     this.attrHostNames = cdk.Token.asList(this.getAtt("HostNames"));
     this.attrState = cdk.Token.asString(this.getAtt("State"));
+    this.attrExternalId = cdk.Token.asString(
+      this.getAtt("CloudProviderConfig.ExternalId")
+    );
+    this.attrIamUserARN = cdk.Token.asString(
+      this.getAtt("CloudProviderConfig.IamUserARN")
+    );
+    this.attrIamAssumedRoleARNN = cdk.Token.asString(
+      this.getAtt("CloudProviderConfig.IamAssumedRoleARN")
+    );
   }
 }


### PR DESCRIPTION

## Proposed changes

Allows not setting optional attributes DataProcessRegion and CloudProviderConfig for FederatedDatabaseInstance

Link to any related issue(s): CLOUDP-219922


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
Fixes https://github.com/mongodb/awscdk-resources-mongodbatlas/issues/174