### PR TITLE
feat: Adds globalClusterSelfManagedSharding to cluster

### DIFF
--- a/API.md
+++ b/API.md
@@ -35445,6 +35445,7 @@ const cfnClusterProps: CfnClusterProps = { ... }
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterProps.property.connectionStrings">connectionStrings</a></code> | <code><a href="#awscdk-resources-mongodbatlas.ConnectionStrings">ConnectionStrings</a></code> | Set of connection strings that your applications use to connect to this cluster. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterProps.property.diskSizeGb">diskSizeGb</a></code> | <code>number</code> | Storage capacity that the host's root volume possesses expressed in gigabytes. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterProps.property.encryptionAtRestProvider">encryptionAtRestProvider</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterPropsEncryptionAtRestProvider">CfnClusterPropsEncryptionAtRestProvider</a></code> | Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnClusterProps.property.globalClusterSelfManagedSharding">globalClusterSelfManagedSharding</a></code> | <code>boolean</code> | (Optional) Flag that indicates if cluster uses Atlas-Managed Sharding (false, default) or Self-Managed Sharding (true). |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterProps.property.labels">labels</a></code> | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterPropsLabels">CfnClusterPropsLabels</a>[]</code> | Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterProps.property.mongoDbMajorVersion">mongoDbMajorVersion</a></code> | <code>string</code> | Major MongoDB version of the cluster. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterProps.property.paused">paused</a></code> | <code>boolean</code> | Flag that indicates whether the cluster is paused or not. |
@@ -35569,6 +35570,20 @@ public readonly encryptionAtRestProvider: CfnClusterPropsEncryptionAtRestProvide
 Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster.
 
 To enable customer key management for encryption at rest, the cluster replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize setting must be M10 or higher and "backupEnabled" : false or omitted entirely.
+
+---
+
+##### `globalClusterSelfManagedSharding`<sup>Optional</sup> <a name="globalClusterSelfManagedSharding" id="awscdk-resources-mongodbatlas.CfnClusterProps.property.globalClusterSelfManagedSharding"></a>
+
+```typescript
+public readonly globalClusterSelfManagedSharding: boolean;
+```
+
+- *Type:* boolean
+
+(Optional) Flag that indicates if cluster uses Atlas-Managed Sharding (false, default) or Self-Managed Sharding (true).
+
+It can only be enabled for Global Clusters (`GEOSHARDED`). It cannot be changed once the cluster is created. Use this mode if you're an advanced user and the default configuration is too restrictive for your workload. If you select this option, you must manually configure the sharding strategy, more info [here](https://www.mongodb.com/docs/atlas/tutorial/create-global-cluster/#select-your-sharding-configuration).
 
 ---
 

--- a/src/l1-resources/cluster/index.ts
+++ b/src/l1-resources/cluster/index.ts
@@ -56,6 +56,13 @@ export interface CfnClusterProps {
   readonly encryptionAtRestProvider?: CfnClusterPropsEncryptionAtRestProvider;
 
   /**
+   * (Optional) Flag that indicates if cluster uses Atlas-Managed Sharding (false, default) or Self-Managed Sharding (true). It can only be enabled for Global Clusters (`GEOSHARDED`). It cannot be changed once the cluster is created. Use this mode if you're an advanced user and the default configuration is too restrictive for your workload. If you select this option, you must manually configure the sharding strategy, more info [here](https://www.mongodb.com/docs/atlas/tutorial/create-global-cluster/#select-your-sharding-configuration).
+   *
+   * @schema CfnClusterProps#GlobalClusterSelfManagedSharding
+   */
+  readonly globalClusterSelfManagedSharding?: boolean;
+
+  /**
    * Profile used to provide credentials information, (a secret with the cfn/atlas/profile/{Profile}, is required), if not provided default is used
    *
    * @schema CfnClusterProps#Profile
@@ -158,6 +165,7 @@ export function toJson_CfnClusterProps(
     ConnectionStrings: toJson_ConnectionStrings(obj.connectionStrings),
     DiskSizeGB: obj.diskSizeGb,
     EncryptionAtRestProvider: obj.encryptionAtRestProvider,
+    GlobalClusterSelfManagedSharding: obj.globalClusterSelfManagedSharding,
     Profile: obj.profile,
     ProjectId: obj.projectId,
     Labels: obj.labels?.map((y) => toJson_CfnClusterPropsLabels(y)),


### PR DESCRIPTION
## Proposed changes

Adds globalClusterSelfManagedSharding to cluster

Choosing not to update examples as this is an advanced use case

Link to any related issue(s): CLOUDP-256268


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
Manual testing:

Create
![image](https://github.com/mongodb/awscdk-resources-mongodbatlas/assets/6596097/f5f38e19-d1ed-45d8-9b55-6652db3ef6fe)

UI
![image](https://github.com/mongodb/awscdk-resources-mongodbatlas/assets/6596097/ad7c633a-4f40-4fd4-9de5-2c3240c7d310)


Update
![image](https://github.com/mongodb/awscdk-resources-mongodbatlas/assets/6596097/fc2f5cec-0741-49ca-87d8-0ec663b0c901)

UI
![image](https://github.com/mongodb/awscdk-resources-mongodbatlas/assets/6596097/b79ca92a-b0fe-4005-8d77-9e5a2300afaf)


Delete

![image](https://github.com/mongodb/awscdk-resources-mongodbatlas/assets/6596097/4321bb2f-099b-4a2b-8b8e-ef3efd087186)

