### PR TITLE
chore: DEVPROD-13209: template authenticode key name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
           -e GRS_CONFIG_USER1_PASSWORD="${{ secrets.ARTIFACTORY_SIGN_PASSWORD }}" \
           --rm -v "$(pwd)":"$(pwd)" -w "$(pwd)" \
           "${{ secrets.ARTIFACTORY_REGISTRY }}/${{ secrets.ARTIFACTORY_SIGN_TOOL }}" \
-          /bin/bash -c "jsign --tsaurl http://timestamp.digicert.com -a mongo-authenticode-2021 \
+          /bin/bash -c "jsign --tsaurl http://timestamp.digicert.com -a ${{ secrets.AUTHENTICODE_KEY_NAME }} \
           ./dist/dotnet/MongoDB.AWSCDKResourcesMongoDBAtlas.${{ steps.extract-version.outputs.VERSION }}.nupkg"
       - name: Release
         env:


### PR DESCRIPTION
This commit templates our authenticode key name in preparation for the authenticode 2021 deprecation. The variable will be added to our GHA project as mongo-authenticode-2021, and later updated to 2024 when that certificate is ready.