### PR TITLE
chore: Fix self-referential dependency in MongoDB Atlas private endpoint example

### DIFF
--- a/examples/l1-resources/private-endpoint.ts
+++ b/examples/l1-resources/private-endpoint.ts
@@ -40,7 +40,7 @@ export class CdkPrivateEndpoint extends cdk.Stack {
       id: awsPrivateEndpoint.ref,
     });
 
-    myPrivateEndpoint.addDependency(myPrivateEndpoint)
+    myPrivateEndpoint.addDependency(awsPrivateEndpoint)
   }
 
   getContextProps(): AtlasStackProps {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas AWS CDK Resources!
Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/awscdk-resources-mongodbatlas/blob/master/CONTRIBUTING.md
Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Fixed an incorrect self-referential dependency in the MongoDB Atlas Private Endpoint CDK example.

The original code added a dependency of a resource on itself, which is logically incorrect and could potentially cause deployment issues. The fix replaces the self-dependency with a dependency on the AWS VPC endpoint to ensure correct resource creation order.


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
This is a minor fix to improve the correctness of the example code's dependency management.