### PR TITLE
feat: Adds SkipDefaultAlertsSettings and GenAIFeaturesEnabled to CfnOrganization

### DIFF
--- a/API.md
+++ b/API.md
@@ -38635,10 +38635,12 @@ const cfnOrganizationProps: CfnOrganizationProps = { ... }
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.apiAccessListRequired">apiAccessListRequired</a></code> | <code>boolean</code> | Flag that indicates whether to require API operations to originate from an IP Address added to the API access list for the specified organization. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.apiKey">apiKey</a></code> | <code><a href="#awscdk-resources-mongodbatlas.ApiKey">ApiKey</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.federatedSettingsId">federatedSettingsId</a></code> | <code>string</code> | Unique 24-hexadecimal digit string that identifies the federation to link the newly created organization to. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.genAiFeaturesEnabled">genAiFeaturesEnabled</a></code> | <code>boolean</code> | Flag that indicates whether this organization has access to generative AI features. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.isDeleted">isDeleted</a></code> | <code>boolean</code> | Flag that indicates whether this organization has been deleted. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.multiFactorAuthRequired">multiFactorAuthRequired</a></code> | <code>boolean</code> | Flag that indicates whether to require users to set up Multi-Factor Authentication (MFA) before accessing the specified organization. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.profile">profile</a></code> | <code>string</code> | Profile used to provide credentials information, (a secret with the cfn/atlas/profile/{Profile}, is required), if not provided default is used. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.restrictEmployeeAccess">restrictEmployeeAccess</a></code> | <code>boolean</code> | Flag that indicates whether to block MongoDB Support from accessing Atlas infrastructure for any deployment in the specified organization without explicit permission. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnOrganizationProps.property.skipDefaultAlertsSettings">skipDefaultAlertsSettings</a></code> | <code>boolean</code> | Disables automatic alert creation. |
 
 ---
 
@@ -38716,6 +38718,20 @@ If specified, the proposed Organization Owner of the new organization must have 
 
 ---
 
+##### `genAiFeaturesEnabled`<sup>Optional</sup> <a name="genAiFeaturesEnabled" id="awscdk-resources-mongodbatlas.CfnOrganizationProps.property.genAiFeaturesEnabled"></a>
+
+```typescript
+public readonly genAiFeaturesEnabled: boolean;
+```
+
+- *Type:* boolean
+
+Flag that indicates whether this organization has access to generative AI features.
+
+This setting only applies to Atlas Commercial and defaults to `true`. With this setting on, Project Owners may be able to enable or disable individual AI features at the project level. To learn more, see https://www.mongodb.com/docs/generative-ai-faq/
+
+---
+
 ##### `isDeleted`<sup>Optional</sup> <a name="isDeleted" id="awscdk-resources-mongodbatlas.CfnOrganizationProps.property.isDeleted"></a>
 
 ```typescript
@@ -38765,6 +38781,21 @@ public readonly restrictEmployeeAccess: boolean;
 Flag that indicates whether to block MongoDB Support from accessing Atlas infrastructure for any deployment in the specified organization without explicit permission.
 
 Once this setting is turned on, you can grant MongoDB Support a 24-hour bypass access to the Atlas deployment to resolve support issues. To learn more, see: https://www.mongodb.com/docs/atlas/security-restrict-support-access/.
+
+---
+
+##### `skipDefaultAlertsSettings`<sup>Optional</sup> <a name="skipDefaultAlertsSettings" id="awscdk-resources-mongodbatlas.CfnOrganizationProps.property.skipDefaultAlertsSettings"></a>
+
+```typescript
+public readonly skipDefaultAlertsSettings: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true` for new Atlas Organizations created with the provider to prevent infrastructure drift caused by creation of new alerts.
+
+Disables automatic alert creation.
+
+When set to `true`, Atlas doesn't automatically create organization-level alerts. Defaults to `true` for new Atlas Organizations created with the provider to prevent infrastructure drift caused by creation of new alerts.
 
 ---
 

--- a/examples/l1-resources/organization.ts
+++ b/examples/l1-resources/organization.ts
@@ -29,8 +29,9 @@ export class CdkTestingStack extends cdk.Stack {
       apiKey: {
         roles: ["ORG_OWNER"],
         description: "test-cdk"
-      }
-
+      },
+      skipDefaultAlertsSettings: true,
+      genAiFeaturesEnabled: true
     });
   }
 

--- a/src/l1-resources/organization/index.ts
+++ b/src/l1-resources/organization/index.ts
@@ -49,6 +49,21 @@ export interface CfnOrganizationProps {
   readonly awsSecretName: string;
 
   /**
+   * Disables automatic alert creation. When set to `true`, Atlas doesn't automatically create organization-level alerts. Defaults to `true` for new Atlas Organizations created with the provider to prevent infrastructure drift caused by creation of new alerts.
+   *
+   * @default true` for new Atlas Organizations created with the provider to prevent infrastructure drift caused by creation of new alerts.
+   * @schema CfnOrganizationProps#SkipDefaultAlertsSettings
+   */
+  readonly skipDefaultAlertsSettings?: boolean;
+
+  /**
+   * Flag that indicates whether this organization has access to generative AI features. This setting only applies to Atlas Commercial and defaults to `true`. With this setting on, Project Owners may be able to enable or disable individual AI features at the project level. To learn more, see https://www.mongodb.com/docs/generative-ai-faq/
+   *
+   * @schema CfnOrganizationProps#GenAIFeaturesEnabled
+   */
+  readonly genAiFeaturesEnabled?: boolean;
+
+  /**
    * Flag that indicates whether this organization has been deleted.
    *
    * @schema CfnOrganizationProps#IsDeleted
@@ -94,6 +109,8 @@ export function toJson_CfnOrganizationProps(
     OrgOwnerId: obj.orgOwnerId,
     Profile: obj.profile,
     AwsSecretName: obj.awsSecretName,
+    SkipDefaultAlertsSettings: obj.skipDefaultAlertsSettings,
+    GenAIFeaturesEnabled: obj.genAiFeaturesEnabled,
     IsDeleted: obj.isDeleted,
     ApiAccessListRequired: obj.apiAccessListRequired,
     MultiFactorAuthRequired: obj.multiFactorAuthRequired,


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas AWS CDK Resources!
Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/awscdk-resources-mongodbatlas/blob/master/CONTRIBUTING.md
Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Adds SkipDefaultAlertsSettings and GenAIFeaturesEnabled to CfnOrganization

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->
_Jira ticket:_ [CLOUDP-282825](https://jira.mongodb.org/browse/CLOUDP-282825)

Please include a summary of the fix/feature/change, including any relevant motivation and context.


Link to any related issue(s): 


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
