### PR TITLE
fix: Fixes NuGet Release failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,10 +208,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           path: .repo
+          fetch-depth: 0
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Create dotnet artifact
-        run: cd .repo && npx projen compile && npx projen package:dotnet
+        run: |
+          cd .repo
+          npx projen bump
+          npx projen compile
+          npx projen package:dotnet
       - name: Collect dotnet Artifact
         run: mv .repo/dist/dotnet dist/dotnet
       - name: Extract Version


### PR DESCRIPTION
## Proposed changes

Fixes the release of NuGet ([issue](https://github.com/mongodb/awscdk-resources-mongodbatlas/issues/420))
The error was 
```
jsign: The file ./dist/dotnet/MongoDB.AWSCDKResourcesMongoDBAtlas.3.10.0.nupkg couldn't be found
```
when trying to sign the nuget package.

After investigataion, I realized that the NuGet package was being generated but with the wrong name, `MongoDB.AWSCDKResourcesMongoDBAtlas.0.0.0.nupkg` (not the expected version number).
To fix this the `npx projen bump` command is needed to bump the version in the `package.json` file. The projen bump command needs to:
- Find the latest version tag in the repository
- Determine the next version based on commit history
- Generate a changelog

To do this, it needs access to:
- All git tags (which contain version information)
- The full commit history (to determine what changed since the last release)

That is why I added `fetch-depth: 0` so that the full git history is fetched, instead of just doing a shallow copy (default fetch-depth: 1`)

Tested this change running a modified version of the Action defined here: https://github.com/mongodb/awscdk-resources-mongodbatlas/pull/422 
And with those changes the resulting dotnet package is `MongoDB.AWSCDKResourcesMongoDBAtlas.3.10.0.nupkg`

Link to any related issue(s): CLOUDP-309125

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
