### PR TITLE
chore: Fixes broken CI by sed after cdk-import

### DIFF
--- a/API.md
+++ b/API.md
@@ -45045,6 +45045,7 @@ const processArgs: ProcessArgs = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.customOpensslCipherConfigTls12">customOpensslCipherConfigTls12</a></code> | <code>string[]</code> | The custom OpenSSL cipher suite list for TLS 1.2. This field is only valid when `tls_cipher_config_mode` is set to `CUSTOM`. |
 | <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.defaultReadConcern">defaultReadConcern</a></code> | <code>string</code> | Default level of acknowledgment requested from MongoDB for read operations set for this cluster. |
 | <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.defaultWriteConcern">defaultWriteConcern</a></code> | <code>string</code> | Default level of acknowledgment requested from MongoDB for write operations set for this cluster. |
 | <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.failIndexKeyTooLong">failIndexKeyTooLong</a></code> | <code>boolean</code> | Flag that indicates whether you can insert or update documents where all indexed entries don't exceed 1024 bytes. |
@@ -45055,7 +45056,20 @@ const processArgs: ProcessArgs = { ... }
 | <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.oplogSizeMb">oplogSizeMb</a></code> | <code>number</code> | Storage limit of cluster's oplog expressed in megabytes. |
 | <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.sampleRefreshIntervalBiConnector">sampleRefreshIntervalBiConnector</a></code> | <code>number</code> | Number of documents per database to sample when gathering schema information. |
 | <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.sampleSizeBiConnector">sampleSizeBiConnector</a></code> | <code>number</code> | Interval in seconds at which the mongosqld process re-samples data to create its relational schema. |
+| <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.tlsCipherConfigMode">tlsCipherConfigMode</a></code> | <code>string</code> | The TLS cipher suite configuration mode. |
 | <code><a href="#awscdk-resources-mongodbatlas.ProcessArgs.property.transactionLifetimeLimitSeconds">transactionLifetimeLimitSeconds</a></code> | <code>number</code> | Lifetime, in seconds, of multi-document transactions. |
+
+---
+
+##### `customOpensslCipherConfigTls12`<sup>Optional</sup> <a name="customOpensslCipherConfigTls12" id="awscdk-resources-mongodbatlas.ProcessArgs.property.customOpensslCipherConfigTls12"></a>
+
+```typescript
+public readonly customOpensslCipherConfigTls12: string[];
+```
+
+- *Type:* string[]
+
+The custom OpenSSL cipher suite list for TLS 1.2. This field is only valid when `tls_cipher_config_mode` is set to `CUSTOM`.
 
 ---
 
@@ -45184,6 +45198,20 @@ public readonly sampleSizeBiConnector: number;
 - *Type:* number
 
 Interval in seconds at which the mongosqld process re-samples data to create its relational schema.
+
+---
+
+##### `tlsCipherConfigMode`<sup>Optional</sup> <a name="tlsCipherConfigMode" id="awscdk-resources-mongodbatlas.ProcessArgs.property.tlsCipherConfigMode"></a>
+
+```typescript
+public readonly tlsCipherConfigMode: string;
+```
+
+- *Type:* string
+
+The TLS cipher suite configuration mode.
+
+Valid values include `CUSTOM` or `DEFAULT`. The `DEFAULT` mode uses the default cipher suites. The `CUSTOM` mode allows you to specify custom cipher suites for both TLS 1.2 and TLS 1.3. To unset, this should be set back to `DEFAULT`.
 
 ---
 

--- a/scripts/cdk.sh
+++ b/scripts/cdk.sh
@@ -60,6 +60,7 @@ sed -e 's/UNDERSCORE_//g' -e 's/HYPHEN_//g' -e 's/PERIOD_//g' -e 's/VALUE_//g' "
 # Fix @typescript-eslint/no-shadow es-linter error in file federated-database-instance/index.ts
 sed -e 's/map(y => toJson_TagSet(y))/map(x => toJson_TagSet(x))/g' "${dest}" > "${dest}.tmp" && mv "${dest}.tmp" "${dest}"
 
+# Fix errors like `Definition for rule '@stylistic/max-len' was not found      @stylistic/max-len` until eslint 9 is supported by projen: https://github.com/projen/projen/issues/3240
 sed -e 's|@stylistic/max-len, ||g' -e 's|, @stylistic/quote-props||g' "${dest}" > "${dest}.tmp" && mv "${dest}.tmp" "${dest}"
 
 echo

--- a/scripts/cdk.sh
+++ b/scripts/cdk.sh
@@ -60,5 +60,7 @@ sed -e 's/UNDERSCORE_//g' -e 's/HYPHEN_//g' -e 's/PERIOD_//g' -e 's/VALUE_//g' "
 # Fix @typescript-eslint/no-shadow es-linter error in file federated-database-instance/index.ts
 sed -e 's/map(y => toJson_TagSet(y))/map(x => toJson_TagSet(x))/g' "${dest}" > "${dest}.tmp" && mv "${dest}.tmp" "${dest}"
 
+sed -e 's|@stylistic/max-len, ||g' -e 's|, @stylistic/quote-props||g' "${dest}" > "${dest}.tmp" && mv "${dest}.tmp" "${dest}"
+
 echo
 echo "L1 CDK resource generated succesfully: ${resource}, CFN type: ${resourceType}"

--- a/src/l1-resources/cluster/index.ts
+++ b/src/l1-resources/cluster/index.ts
@@ -231,6 +231,20 @@ export interface ProcessArgs {
   readonly minimumEnabledTlsProtocol?: string;
 
   /**
+   * The TLS cipher suite configuration mode. Valid values include `CUSTOM` or `DEFAULT`. The `DEFAULT` mode uses the default cipher suites. The `CUSTOM` mode allows you to specify custom cipher suites for both TLS 1.2 and TLS 1.3. To unset, this should be set back to `DEFAULT`.
+   *
+   * @schema processArgs#TlsCipherConfigMode
+   */
+  readonly tlsCipherConfigMode?: string;
+
+  /**
+   * The custom OpenSSL cipher suite list for TLS 1.2. This field is only valid when `tls_cipher_config_mode` is set to `CUSTOM`.
+   *
+   * @schema processArgs#CustomOpensslCipherConfigTls12
+   */
+  readonly customOpensslCipherConfigTls12?: string[];
+
+  /**
    * Flag that indicates whether the cluster disables executing any query that requires a collection scan to return results.
    *
    * @schema processArgs#NoTableScan
@@ -289,6 +303,10 @@ export function toJson_ProcessArgs(
     FailIndexKeyTooLong: obj.failIndexKeyTooLong,
     JavascriptEnabled: obj.javascriptEnabled,
     MinimumEnabledTLSProtocol: obj.minimumEnabledTlsProtocol,
+    TlsCipherConfigMode: obj.tlsCipherConfigMode,
+    CustomOpensslCipherConfigTls12: obj.customOpensslCipherConfigTls12?.map(
+      (y) => y
+    ),
     NoTableScan: obj.noTableScan,
     OplogSizeMB: obj.oplogSizeMb,
     SampleSizeBIConnector: obj.sampleSizeBiConnector,


### PR DESCRIPTION
## Proposed changes

- Hard to fix bug, as generated resources where changed after `npm install -g cdk-import` changed the behavior (not locked to a version in any workflow)
- Simplest solution I could find is to avoid the `@stylistic/{rule-name}` directly in the cdk.sh script.
- I tried locking in version for cdk-import but couldn't find exactly the right one to pick or if it depends on other packages, therefore, changing directly in cdk.sh seemed like the natrual choice.

## More context
The generated typescript code contained different @stylistic linter rules that made our code-health pipeline fail (first [failure](https://github.com/mongodb/awscdk-resources-mongodbatlas/actions/runs/15007637017) about ~1 week ago, last [OK](https://github.com/mongodb/awscdk-resources-mongodbatlas/actions/runs/14797057885) ~3 weeks ago).

A bit more background. projen doesn't support eslint 9 yet, so the stylistic plugin for eslint is not generated. See more in the projen issues:

[Eslint no longer functional due to deprecated configuration](https://github.com/projen/projen/issues/3950)
[support-implementation-issue](https://github.com/projen/projen/issues/3240)


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
