### PR TITLE
fix: Propagate optional profile property from L3 to L1 constructs in atlas-basic-private-endpoint

### DIFF
--- a/src/l3-resources/atlas-basic-private-endpoint/index.ts
+++ b/src/l3-resources/atlas-basic-private-endpoint/index.ts
@@ -67,6 +67,7 @@ export class AtlasBasicPrivateEndpoint extends Construct {
       this,
       "atlas-private-endpoint-service-".concat(id),
       {
+        profile: props.profile,
         projectId: this.atlasBasic.mProject.attrId,
         region: region.toUpperCase().replace(/-/g, "_"),
         cloudProvider: CfnPrivateEndpointServicePropsCloudProvider.AWS,
@@ -90,6 +91,7 @@ export class AtlasBasicPrivateEndpoint extends Construct {
       this,
       "atlas-private-endpoint-".concat(id),
       {
+        profile: props.profile,
         projectId: this.atlasBasic.mProject.attrId,
         endpointServiceId: this.privateEndpointService.attrId,
         id: this.awsPrivateEndpoint.ref,


### PR DESCRIPTION
## Proposed changes

Cherry-picking changes from https://github.com/mongodb/awscdk-resources-mongodbatlas/pull/485

Correctly propagates optional profile property from L3 to L1 constructs. Same pattern is seen in our other L3 resources (`atlas-basic`, `atlas-basic-serverless-private-endpoint`).

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [ ] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
