### PR TITLE
ci(dependency-review): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,6 +5,9 @@
 name: Dependency Review
 on:
   pull_request: {}
+permissions:
+  contents: read
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `dependency-review` workflow only checks dependency changes on PR. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 hardening pattern. YAML validated locally.