### PR TITLE
chore: Restrict GITHUB_TOKEN permissions on GitHub Actions workflows

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -23,6 +23,7 @@ jobs:
         run: npx projen compile
   lint:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: actionlint
@@ -41,6 +42,7 @@ jobs:
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Run ShellCheck

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,6 +5,9 @@
 name: Dependency Review
 on:
   pull_request: {}
+permissions:
+  contents: read
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-408321

Declares explicit `permissions:` blocks on the GitHub Actions workflows that were inheriting repository-default `GITHUB_TOKEN` permissions. This is defense-in-depth hardening against supply-chain compromises like CVE-2025-30066 (`tj-actions/changed-files`): if any third-party action is ever compromised, an explicit cap limits the token's blast radius.

- `dependency-review.yml`: workflow-level `contents: read` (cherry-picked from #593, preserving Arpit Jain as author).
- `stale.yml`: workflow-level `contents: read` + `issues: write` + `pull-requests: write` (required by `actions/stale`).
- `code-health.yml`: `permissions: {}` on the `lint` and `shellcheck` jobs (the other three jobs already declare explicit permissions).

Link to any related issue(s): CLOUDP-408321

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments