### PR TITLE
chore: Fix npm dependency security vulnerabilities

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.248.0",
+      "version": "^2.260.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -51,7 +51,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   authorAddress: "https://www.mongodb.com/",
   description:
     "MongoDB Atlas CDK Construct Library for AWS CloudFormation Resources",
-  cdkVersion: "2.248.0",
+  cdkVersion: "2.260.0",
   constructsVersion: "10.5.0",
   defaultReleaseBranch: "main",
   name: "awscdk-resources-mongodbatlas",

--- a/API.md
+++ b/API.md
@@ -864,7 +864,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAccessListApiKey.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -1107,6 +1109,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyRemovalPolicy"></a>
 
 ```typescript
@@ -1137,6 +1158,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -1192,7 +1225,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnAccessListApiKey.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -1547,7 +1580,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAlertConfiguration.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -1790,6 +1825,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration.applyRemovalPolicy"></a>
 
 ```typescript
@@ -1820,6 +1874,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -1875,7 +1941,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnAlertConfiguration.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -2269,7 +2335,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnApiKey.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -2512,6 +2580,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnApiKey.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnApiKey.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnApiKey.applyRemovalPolicy"></a>
 
 ```typescript
@@ -2542,6 +2629,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnApiKey.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnApiKey.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnApiKey.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -2597,7 +2696,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnApiKey.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -2978,7 +3077,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnAuditing.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -3221,6 +3322,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnAuditing.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnAuditing.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnAuditing.applyRemovalPolicy"></a>
 
 ```typescript
@@ -3251,6 +3371,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnAuditing.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnAuditing.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnAuditing.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -3306,7 +3438,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnAuditing.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -3687,7 +3819,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -3930,6 +4064,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.applyRemovalPolicy"></a>
 
 ```typescript
@@ -3960,6 +4113,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -4015,7 +4180,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnBackupCompliancePolicy.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -4396,7 +4561,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -4639,6 +4806,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.applyRemovalPolicy"></a>
 
 ```typescript
@@ -4669,6 +4855,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -4724,7 +4922,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnCloudBackUpRestoreJobs.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -5170,7 +5368,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -5413,6 +5613,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.applyRemovalPolicy"></a>
 
 ```typescript
@@ -5443,6 +5662,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -5498,7 +5729,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnCloudBackupSchedule.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -5866,7 +6097,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -6109,6 +6342,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.applyRemovalPolicy"></a>
 
 ```typescript
@@ -6139,6 +6391,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -6194,7 +6458,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshot.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -6692,7 +6956,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -6935,6 +7201,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.applyRemovalPolicy"></a>
 
 ```typescript
@@ -6965,6 +7250,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -7020,7 +7317,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnCloudBackupSnapshotExportBucket.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -7375,7 +7672,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCluster.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -7618,6 +7917,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnCluster.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnCluster.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnCluster.applyRemovalPolicy"></a>
 
 ```typescript
@@ -7648,6 +7966,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnCluster.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnCluster.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnCluster.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -7703,7 +8033,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnCluster.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -8097,7 +8427,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -8340,6 +8672,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.applyRemovalPolicy"></a>
 
 ```typescript
@@ -8370,6 +8721,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -8425,7 +8788,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnClusterOutageSimulation.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -8806,7 +9169,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDbRole.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -9049,6 +9414,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnCustomDbRole.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnCustomDbRole.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnCustomDbRole.applyRemovalPolicy"></a>
 
 ```typescript
@@ -9079,6 +9463,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnCustomDbRole.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnCustomDbRole.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnCustomDbRole.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -9134,7 +9530,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnCustomDbRole.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -9476,7 +9872,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -9719,6 +10117,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.applyRemovalPolicy"></a>
 
 ```typescript
@@ -9749,6 +10166,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -9804,7 +10233,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnCustomDnsConfigurationClusterAws.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -10146,7 +10575,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnDatabaseUser.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -10389,6 +10820,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnDatabaseUser.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnDatabaseUser.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnDatabaseUser.applyRemovalPolicy"></a>
 
 ```typescript
@@ -10419,6 +10869,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnDatabaseUser.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnDatabaseUser.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnDatabaseUser.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -10474,7 +10936,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnDatabaseUser.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -10829,7 +11291,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnEncryptionAtRest.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -11072,6 +11536,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnEncryptionAtRest.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnEncryptionAtRest.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnEncryptionAtRest.applyRemovalPolicy"></a>
 
 ```typescript
@@ -11102,6 +11585,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnEncryptionAtRest.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnEncryptionAtRest.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnEncryptionAtRest.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -11157,7 +11652,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnEncryptionAtRest.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -11512,7 +12007,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -11755,6 +12252,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.applyRemovalPolicy"></a>
 
 ```typescript
@@ -11785,6 +12301,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -11840,7 +12368,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnFederatedDatabaseInstance.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -12208,7 +12736,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -12451,6 +12981,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.applyRemovalPolicy"></a>
 
 ```typescript
@@ -12481,6 +13030,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -12536,7 +13097,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnFederatedQueryLimit.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -12930,7 +13491,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -13173,6 +13736,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.applyRemovalPolicy"></a>
 
 ```typescript
@@ -13203,6 +13785,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -13258,7 +13852,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsIdentityProvider.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -13626,7 +14220,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -13869,6 +14465,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.applyRemovalPolicy"></a>
 
 ```typescript
@@ -13899,6 +14514,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -13954,7 +14581,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnFederatedSettingsOrgRoleMapping.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -14309,7 +14936,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnFlexCluster.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -14552,6 +15181,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnFlexCluster.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnFlexCluster.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnFlexCluster.applyRemovalPolicy"></a>
 
 ```typescript
@@ -14582,6 +15230,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnFlexCluster.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnFlexCluster.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnFlexCluster.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -14637,7 +15297,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnFlexCluster.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -15057,7 +15717,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -15300,6 +15962,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.applyRemovalPolicy"></a>
 
 ```typescript
@@ -15330,6 +16011,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -15385,7 +16078,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnGlobalClusterConfig.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -15740,7 +16433,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapConfiguration.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -15983,6 +16678,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnLdapConfiguration.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnLdapConfiguration.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnLdapConfiguration.applyRemovalPolicy"></a>
 
 ```typescript
@@ -16013,6 +16727,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnLdapConfiguration.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnLdapConfiguration.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnLdapConfiguration.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -16068,7 +16794,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnLdapConfiguration.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -16410,7 +17136,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLdapVerify.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -16653,6 +17381,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnLdapVerify.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnLdapVerify.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnLdapVerify.applyRemovalPolicy"></a>
 
 ```typescript
@@ -16683,6 +17430,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnLdapVerify.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnLdapVerify.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnLdapVerify.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -16738,7 +17497,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnLdapVerify.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -17106,7 +17865,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnLogIntegration.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -17349,6 +18110,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnLogIntegration.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnLogIntegration.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnLogIntegration.applyRemovalPolicy"></a>
 
 ```typescript
@@ -17379,6 +18159,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnLogIntegration.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnLogIntegration.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnLogIntegration.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -17434,7 +18226,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnLogIntegration.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -17789,7 +18581,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMaintenanceWindow.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -18032,6 +18826,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnMaintenanceWindow.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnMaintenanceWindow.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnMaintenanceWindow.applyRemovalPolicy"></a>
 
 ```typescript
@@ -18062,6 +18875,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnMaintenanceWindow.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnMaintenanceWindow.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnMaintenanceWindow.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -18117,7 +18942,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnMaintenanceWindow.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -18498,7 +19323,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -18741,6 +19568,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.applyRemovalPolicy"></a>
 
 ```typescript
@@ -18771,6 +19617,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -18826,7 +19684,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnMongoDbEmployeeAccessGrant.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -19168,7 +20026,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkContainer.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -19411,6 +20271,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnNetworkContainer.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnNetworkContainer.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnNetworkContainer.applyRemovalPolicy"></a>
 
 ```typescript
@@ -19441,6 +20320,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnNetworkContainer.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnNetworkContainer.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnNetworkContainer.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -19496,7 +20387,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnNetworkContainer.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -19851,7 +20742,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnNetworkPeering.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -20094,6 +20987,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnNetworkPeering.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnNetworkPeering.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnNetworkPeering.applyRemovalPolicy"></a>
 
 ```typescript
@@ -20124,6 +21036,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnNetworkPeering.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnNetworkPeering.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnNetworkPeering.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -20179,7 +21103,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnNetworkPeering.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -20573,7 +21497,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOnlineArchive.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -20816,6 +21742,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnOnlineArchive.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnOnlineArchive.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnOnlineArchive.applyRemovalPolicy"></a>
 
 ```typescript
@@ -20846,6 +21791,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnOnlineArchive.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnOnlineArchive.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnOnlineArchive.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -20901,7 +21858,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnOnlineArchive.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -21282,7 +22239,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrganization.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -21525,6 +22484,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnOrganization.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnOrganization.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnOrganization.applyRemovalPolicy"></a>
 
 ```typescript
@@ -21555,6 +22533,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnOrganization.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnOrganization.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnOrganization.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -21610,7 +22600,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnOrganization.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -21965,7 +22955,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnOrgInvitation.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -22208,6 +23200,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnOrgInvitation.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnOrgInvitation.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnOrgInvitation.applyRemovalPolicy"></a>
 
 ```typescript
@@ -22238,6 +23249,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnOrgInvitation.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnOrgInvitation.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnOrgInvitation.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -22293,7 +23316,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnOrgInvitation.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -22687,7 +23710,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpoint.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -22930,6 +23955,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnPrivateEndpoint.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnPrivateEndpoint.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnPrivateEndpoint.applyRemovalPolicy"></a>
 
 ```typescript
@@ -22960,6 +24004,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnPrivateEndpoint.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivateEndpoint.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivateEndpoint.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -23015,7 +24071,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnPrivateEndpoint.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -23383,7 +24439,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -23626,6 +24684,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.applyRemovalPolicy"></a>
 
 ```typescript
@@ -23656,6 +24733,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -23711,7 +24800,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointAws.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -24105,7 +25194,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -24348,6 +25439,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.applyRemovalPolicy"></a>
 
 ```typescript
@@ -24378,6 +25488,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -24433,7 +25555,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnPrivateEndPointRegionalMode.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -24775,7 +25897,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivateEndpointService.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -25018,6 +26142,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointService.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointService.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointService.applyRemovalPolicy"></a>
 
 ```typescript
@@ -25048,6 +26191,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointService.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointService.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointService.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -25103,7 +26258,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnPrivateEndpointService.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -25510,7 +26665,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -25753,6 +26910,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.applyRemovalPolicy"></a>
 
 ```typescript
@@ -25783,6 +26959,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -25838,7 +27026,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnPrivatelinkEndpointServiceDataFederationOnlineArchive.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -26180,7 +27368,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProject.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProject.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProject.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProject.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProject.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProject.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProject.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProject.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProject.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -26423,6 +27613,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnProject.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnProject.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnProject.applyRemovalPolicy"></a>
 
 ```typescript
@@ -26453,6 +27662,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnProject.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnProject.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnProject.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -26508,7 +27729,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnProject.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -26889,7 +28110,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectInvitation.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -27132,6 +28355,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnProjectInvitation.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnProjectInvitation.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnProjectInvitation.applyRemovalPolicy"></a>
 
 ```typescript
@@ -27162,6 +28404,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnProjectInvitation.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectInvitation.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectInvitation.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -27217,7 +28471,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnProjectInvitation.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -27611,7 +28865,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectIpAccessList.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -27854,6 +29110,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnProjectIpAccessList.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnProjectIpAccessList.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnProjectIpAccessList.applyRemovalPolicy"></a>
 
 ```typescript
@@ -27884,6 +29159,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnProjectIpAccessList.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectIpAccessList.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectIpAccessList.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -27939,7 +29226,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnProjectIpAccessList.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -28294,7 +29581,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccount.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -28537,6 +29826,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccount.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccount.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccount.applyRemovalPolicy"></a>
 
 ```typescript
@@ -28567,6 +29875,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccount.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccount.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccount.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -28622,7 +29942,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccount.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -28990,7 +30310,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -29233,6 +30555,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.applyRemovalPolicy"></a>
 
 ```typescript
@@ -29263,6 +30604,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -29318,7 +30671,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountAccessListEntry.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -29712,7 +31065,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -29955,6 +31310,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.applyRemovalPolicy"></a>
 
 ```typescript
@@ -29985,6 +31359,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -30040,7 +31426,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnProjectServiceAccountSecret.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -30460,7 +31846,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnResourcePolicy.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -30703,6 +32091,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnResourcePolicy.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnResourcePolicy.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnResourcePolicy.applyRemovalPolicy"></a>
 
 ```typescript
@@ -30733,6 +32140,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnResourcePolicy.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnResourcePolicy.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnResourcePolicy.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -30788,7 +32207,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnResourcePolicy.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -31182,7 +32601,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchDeployment.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -31425,6 +32846,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnSearchDeployment.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnSearchDeployment.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnSearchDeployment.applyRemovalPolicy"></a>
 
 ```typescript
@@ -31455,6 +32895,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnSearchDeployment.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnSearchDeployment.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnSearchDeployment.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -31510,7 +32962,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnSearchDeployment.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -31891,7 +33343,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnSearchIndex.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -32134,6 +33588,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnSearchIndex.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnSearchIndex.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnSearchIndex.applyRemovalPolicy"></a>
 
 ```typescript
@@ -32164,6 +33637,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnSearchIndex.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnSearchIndex.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnSearchIndex.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -32219,7 +33704,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnSearchIndex.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -32587,7 +34072,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccount.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -32830,6 +34317,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnServiceAccount.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnServiceAccount.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnServiceAccount.applyRemovalPolicy"></a>
 
 ```typescript
@@ -32860,6 +34366,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnServiceAccount.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnServiceAccount.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnServiceAccount.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -32915,7 +34433,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnServiceAccount.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -33283,7 +34801,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -33526,6 +35046,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.applyRemovalPolicy"></a>
 
 ```typescript
@@ -33556,6 +35095,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -33611,7 +35162,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnServiceAccountAccessListEntry.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -34005,7 +35556,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -34248,6 +35801,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.applyRemovalPolicy"></a>
 
 ```typescript
@@ -34278,6 +35850,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -34333,7 +35917,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnServiceAccountProjectAssignment.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -34675,7 +36259,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnServiceAccountSecret.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -34918,6 +36504,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnServiceAccountSecret.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnServiceAccountSecret.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnServiceAccountSecret.applyRemovalPolicy"></a>
 
 ```typescript
@@ -34948,6 +36553,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnServiceAccountSecret.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnServiceAccountSecret.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnServiceAccountSecret.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -35003,7 +36620,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnServiceAccountSecret.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -35423,7 +37040,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamConnection.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -35666,6 +37285,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnStreamConnection.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnStreamConnection.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnStreamConnection.applyRemovalPolicy"></a>
 
 ```typescript
@@ -35696,6 +37334,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnStreamConnection.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamConnection.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamConnection.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -35751,7 +37401,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnStreamConnection.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -36093,7 +37743,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamInstance.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -36336,6 +37988,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnStreamInstance.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnStreamInstance.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnStreamInstance.applyRemovalPolicy"></a>
 
 ```typescript
@@ -36366,6 +38037,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnStreamInstance.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamInstance.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamInstance.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -36421,7 +38104,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnStreamInstance.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -36789,7 +38472,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -37032,6 +38717,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.applyRemovalPolicy"></a>
 
 ```typescript
@@ -37062,6 +38766,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -37117,7 +38833,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnStreamPrivatelinkEndpoint.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -37537,7 +39253,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamProcessor.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -37780,6 +39498,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnStreamProcessor.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnStreamProcessor.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnStreamProcessor.applyRemovalPolicy"></a>
 
 ```typescript
@@ -37810,6 +39547,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnStreamProcessor.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamProcessor.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamProcessor.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -37865,7 +39614,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnStreamProcessor.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -38246,7 +39995,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnStreamWorkspace.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -38489,6 +40240,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnStreamWorkspace.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnStreamWorkspace.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnStreamWorkspace.applyRemovalPolicy"></a>
 
 ```typescript
@@ -38519,6 +40289,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnStreamWorkspace.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamWorkspace.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnStreamWorkspace.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -38574,7 +40356,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnStreamWorkspace.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -38942,7 +40724,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTeams.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -39185,6 +40969,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnTeams.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnTeams.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnTeams.applyRemovalPolicy"></a>
 
 ```typescript
@@ -39215,6 +41018,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnTeams.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnTeams.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnTeams.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -39270,7 +41085,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnTeams.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -39625,7 +41440,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -39868,6 +41685,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.applyRemovalPolicy"></a>
 
 ```typescript
@@ -39898,6 +41734,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -39953,7 +41801,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnThirdPartyIntegration.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -40295,7 +42143,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnTrigger.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -40538,6 +42388,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnTrigger.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnTrigger.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnTrigger.applyRemovalPolicy"></a>
 
 ```typescript
@@ -40568,6 +42437,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnTrigger.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnTrigger.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnTrigger.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -40623,7 +42504,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnTrigger.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.
@@ -40978,7 +42859,9 @@ resource properties.
 | <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.addOverride">addOverride</a></code> | Adds an override to the synthesized CloudFormation resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.addPropertyDeletionOverride">addPropertyDeletionOverride</a></code> | Adds an override that deletes the value of a property from the resource definition. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.addPropertyOverride">addPropertyOverride</a></code> | Adds an override to a resource property. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.applyCrossStackReferenceStrength">applyCrossStackReferenceStrength</a></code> | Sets the cross-stack reference strength for this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.applyRemovalPolicy">applyRemovalPolicy</a></code> | Sets the deletion policy of the resource based on the removal policy specified. |
+| <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.cfnPropertyName">cfnPropertyName</a></code> | *No description.* |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.getAtt">getAtt</a></code> | Returns a token for an runtime attribute of this resource. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.getMetadata">getMetadata</a></code> | Retrieve a value value from the CloudFormation Resource Metadata. |
 | <code><a href="#awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.obtainDependencies">obtainDependencies</a></code> | Retrieves an array of resources this resource depends on. |
@@ -41221,6 +43104,25 @@ The value.
 
 ---
 
+##### `applyCrossStackReferenceStrength` <a name="applyCrossStackReferenceStrength" id="awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.applyCrossStackReferenceStrength"></a>
+
+```typescript
+public applyCrossStackReferenceStrength(strength: ReferenceStrength): void
+```
+
+Sets the cross-stack reference strength for this resource.
+
+When set, any cross-stack reference to this resource will use the specified
+strength instead of the global default from the consuming stack's context.
+
+###### `strength`<sup>Required</sup> <a name="strength" id="awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.applyCrossStackReferenceStrength.parameter.strength"></a>
+
+- *Type:* aws-cdk-lib.ReferenceStrength
+
+The reference strength to use for this resource.
+
+---
+
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.applyRemovalPolicy"></a>
 
 ```typescript
@@ -41251,6 +43153,18 @@ can be found in the following link:
 ###### `options`<sup>Optional</sup> <a name="options" id="awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.applyRemovalPolicy.parameter.options"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicyOptions
+
+---
+
+##### `cfnPropertyName` <a name="cfnPropertyName" id="awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.cfnPropertyName"></a>
+
+```typescript
+public cfnPropertyName(cdkPropertyName: string): string
+```
+
+###### `cdkPropertyName`<sup>Required</sup> <a name="cdkPropertyName" id="awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.cfnPropertyName.parameter.cdkPropertyName"></a>
+
+- *Type:* string
 
 ---
 
@@ -41306,7 +43220,7 @@ node metadata ends up in the Cloud Assembly.)
 ##### `obtainDependencies` <a name="obtainDependencies" id="awscdk-resources-mongodbatlas.CfnX509AuthenticationDatabaseUser.obtainDependencies"></a>
 
 ```typescript
-public obtainDependencies(): (Stack | CfnResource)[]
+public obtainDependencies(): (CfnResource | Stack)[]
 ```
 
 Retrieves an array of resources this resource depends on.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11454,20 +11454,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/projen/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/projen/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
@@ -11494,29 +11480,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/projen/node_modules/execa": {
-      "version": "5.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/projen/node_modules/fast-glob": {
@@ -11583,18 +11546,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/projen/node_modules/get-stream": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/projen/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -11611,15 +11562,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/projen/node_modules/human-signals": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
       }
     },
     "node_modules/projen/node_modules/ini": {
@@ -11668,18 +11610,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/projen/node_modules/is-stream": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/projen/node_modules/isexe": {
@@ -11731,12 +11661,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/projen/node_modules/merge-stream": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/projen/node_modules/merge2": {
       "version": "1.4.1",
       "dev": true,
@@ -11771,15 +11695,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/projen/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/projen/node_modules/minimist": {
       "version": "1.2.8",
       "dev": true,
@@ -11787,33 +11702,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/projen/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/projen/node_modules/onetime": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/projen/node_modules/parse-conflict-json": {
@@ -11828,15 +11716,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/projen/node_modules/path-key": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/projen/node_modules/queue-microtask": {
@@ -11922,40 +11801,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/projen/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/projen/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/projen/node_modules/shelljs": {
-      "version": "0.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/projen/node_modules/shx": {
       "version": "0.4.0",
       "dev": true,
@@ -11970,6 +11815,164 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/shelljs": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
+      "integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/projen/node_modules/shx/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/projen/node_modules/signal-exit": {
@@ -12004,15 +12007,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/projen/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/projen/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -12035,21 +12029,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/projen/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/projen/node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^16 <= 16.18.78",
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
-        "aws-cdk-lib": "2.248.0",
+        "aws-cdk-lib": "2.260.0",
         "commit-and-tag-version": "^12",
         "constructs": "10.5.0",
         "eslint": "^9",
@@ -34,28 +34,28 @@
         "typescript": "^5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.260.0",
         "constructs": "^10.5.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.13.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.13.0.tgz",
-      "integrity": "sha512-LgRc8Sl1VzuhhPWmJ4hpajBe8Y8coA3KbpAmej7X4nPvWO/x4nUoZSysUKCx2YldLAAYlzwc0mkDHmc/YMZ6vg==",
+      "version": "54.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.3.0.tgz",
+      "integrity": "sha512-1dCM2TXo4PFFKu6sO4qvS0i3d6kxdjuzEFkN7S4xu8nJ+edJRO+DHE7/ttym5ZfAZShAyMY20BhnyTycQN1/jg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -63,15 +63,15 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -80,7 +80,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -92,13 +92,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -117,21 +117,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -165,14 +165,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -182,14 +182,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -226,9 +226,9 @@
       "license": "ISC"
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -236,29 +236,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -288,9 +288,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -308,27 +308,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -561,33 +561,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -595,14 +595,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2920,9 +2920,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.248.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.248.0.tgz",
-      "integrity": "sha512-PGQycx/OdyX+t0o6QUFI1KJAOLoyIVj2WwrN0syrwCi8lYxW2KzldZsW0X+/UN/ALNQwcjSr927ImTpuDOh+bg==",
+      "version": "2.260.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
+      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -2940,19 +2940,19 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
         "yaml": "1.10.3"
       },
@@ -2964,44 +2964,19 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.0",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.5",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -3011,7 +2986,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3069,7 +3044,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3120,7 +3095,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "dev": true,
       "funding": [
         {
@@ -3136,7 +3111,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3180,7 +3155,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3261,7 +3236,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3533,13 +3508,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
-      "integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -3586,9 +3564,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/browserslist": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
-      "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -3606,11 +3584,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.19",
-        "caniuse-lite": "^1.0.30001751",
-        "electron-to-chromium": "^1.5.238",
-        "node-releases": "^2.0.26",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3738,9 +3716,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001753",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
-      "integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -4710,9 +4688,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.245",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.245.tgz",
-      "integrity": "sha512-rdmGfW47ZhL/oWEJAY4qxRtdly2B98ooTJ0pdEI4jhVLZ6tNf8fPtov2wS1IRKwFJT92le3x4Knxiwzl7cPPpQ==",
+      "version": "1.5.375",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -5583,9 +5561,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -5595,7 +5573,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -5752,6 +5731,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
+      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -6287,9 +6283,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7727,23 +7723,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jest-environment-jsdom/node_modules/form-data": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/html-encoding-sniffer": {
@@ -9213,10 +9192,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10617,11 +10606,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
@@ -11462,6 +11454,20 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/projen/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/projen/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
@@ -11488,6 +11494,29 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/projen/node_modules/execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/projen/node_modules/fast-glob": {
@@ -11554,6 +11583,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/projen/node_modules/get-stream": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/projen/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -11570,6 +11611,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/human-signals": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/projen/node_modules/ini": {
@@ -11618,6 +11668,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/projen/node_modules/is-stream": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/projen/node_modules/isexe": {
@@ -11669,6 +11731,12 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/projen/node_modules/merge-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/projen/node_modules/merge2": {
       "version": "1.4.1",
       "dev": true,
@@ -11703,6 +11771,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/projen/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/projen/node_modules/minimist": {
       "version": "1.2.8",
       "dev": true,
@@ -11710,6 +11787,33 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/projen/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/projen/node_modules/parse-conflict-json": {
@@ -11724,6 +11828,15 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/projen/node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/projen/node_modules/queue-microtask": {
@@ -11809,6 +11922,40 @@
         "node": ">=10"
       }
     },
+    "node_modules/projen/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs": {
+      "version": "0.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "fast-glob": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/projen/node_modules/shx": {
       "version": "0.4.0",
       "dev": true,
@@ -11823,164 +11970,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/cross-spawn": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/shelljs": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
-      "integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "execa": "^1.0.0",
-        "fast-glob": "^3.3.2",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/projen/node_modules/shx/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/projen/node_modules/signal-exit": {
@@ -12015,6 +12004,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/projen/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/projen/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -12037,6 +12035,21 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/projen/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/projen/node_modules/wrap-ansi": {
@@ -13882,9 +13895,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -14220,6 +14233,22 @@
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^16 <= 16.18.78",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.248.0",
+    "aws-cdk-lib": "2.260.0",
     "commit-and-tag-version": "^12",
     "constructs": "10.5.0",
     "eslint": "^9",
@@ -64,7 +64,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.260.0",
     "constructs": "^10.5.0"
   },
   "keywords": [


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-414867

Fix npm dependency security vulnerabilities reported by Dependabot. Six alerts are resolved: `fast-uri` (path traversal + host confusion, high) via bumping `aws-cdk-lib` from 2.248.0 to 2.260.0 (the package bundles `fast-uri` transitively and 2.260.0 ships 3.1.2); `form-data`, `@babel/core`, `fast-xml-builder`, and `js-yaml` via lock file updates to their patched versions. `API.md` is regenerated because the `aws-cdk-lib` bump exposes two new methods on the base `CfnResource` class.

Two alerts remain unfixed (complex upstream changes required): `@tootallnate/once` (low) and `js-yaml@3.14.2` inside `@istanbuljs/load-nyc-config` (medium). Both are dev-only test infrastructure.

Link to any related issue(s): CLOUDP-414867


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments