### PR TITLE
chore: Fix js-yaml CVE-2026-53550 via npm overrides

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -137,6 +137,9 @@ project.tasks.tryFind("docgen").updateStep(0, {
   exec: "jsii-docgen -o API.md -r",
   say: "Generating API.md, using -r to include readme content",
 });
+// Force js-yaml >=4.2.0 to fix CVE-2026-53550 (GHSA-h67p-54hq-rp68). @istanbuljs/load-nyc-config
+// pins ^3.13.1 and has no 4.x release yet, so an override is the only fix. Remove once that
+// package updates its own dependency range.
 project.package.addField("overrides", { "js-yaml": "^4.2.0" });
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -137,4 +137,6 @@ project.tasks.tryFind("docgen").updateStep(0, {
   exec: "jsii-docgen -o API.md -r",
   say: "Generating API.md, using -r to include readme content",
 });
+project.package.addField("overrides", { "js-yaml": "^4.2.0" });
+
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -138,8 +138,8 @@ project.tasks.tryFind("docgen").updateStep(0, {
   say: "Generating API.md, using -r to include readme content",
 });
 // Force js-yaml >=4.2.0 to fix CVE-2026-53550 (GHSA-h67p-54hq-rp68). @istanbuljs/load-nyc-config
-// pins ^3.13.1 and has no 4.x release yet, so an override is the only fix. Remove once that
-// package updates its own dependency range.
-project.package.addField("overrides", { "js-yaml": "^4.2.0" });
+// pins ^3.13.1 and has no 4.x release yet, so an override is the only fix. Once that package
+// updates its own dependency range this override becomes a harmless no-op and can be deleted.
+project.package.addField("overrides", { "js-yaml": ">=4.2.0" });
 
 project.synth();

--- a/package-lock.json
+++ b/package-lock.json
@@ -917,16 +917,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -939,20 +929,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -12749,13 +12725,6 @@
       "dependencies": {
         "readable-stream": "^3.0.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "aws-cdk-lib": "^2.260.0",
     "constructs": "^10.5.0"
   },
+  "overrides": {
+    "js-yaml": "^4.2.0"
+  },
   "keywords": [
     "atlas",
     "aws-cdk",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "constructs": "^10.5.0"
   },
   "overrides": {
-    "js-yaml": "^4.2.0"
+    "js-yaml": ">=4.2.0"
   },
   "keywords": [
     "atlas",


### PR DESCRIPTION
## Proposed changes

Fixes Dependabot alert #212 (CVE-2026-53550, GHSA-h67p-54hq-rp68, medium). `js-yaml` ≤ 4.1.1 is vulnerable to a quadratic-complexity DoS via repeated aliases in YAML merge keys.

`js-yaml` 3.14.2 was present as a nested transitive dependency under `@istanbuljs/load-nyc-config`, which pins `^3.13.1`. Since no upstream upgrade resolves this, an npm `overrides` entry (`"js-yaml": "^4.2.0"`) is added via projen. The nested 3.x copy is gone from `package-lock.json` after `npm install`.

Link to any related issue(s): 


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] I have tested the CDK constructor in a CFN stack. See [TESTING.md](../TESTING.md)
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments