### PR TITLE
chore: Migrate SilkBomb workflows to ECR

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -7,28 +7,6 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 jobs:
-  # TEMPORARY: validates ECR access for SilkBomb, remove before merge.
-  silkbomb-ecr-access:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    env:
-      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
-      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
-      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
-    steps:
-      - name: Configure AWS credentials for DevProd Platforms ECR
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
-        with:
-          role-to-assume: ${{ env.ECR_ROLE_ARN }}
-          aws-region: us-east-1
-      - name: Authenticate Docker to DevProd Platforms ECR
-        run: |
-          aws ecr get-login-password --region us-east-1 |
-            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
-          docker pull "${SILKBOMB_IMG}"
-      - name: Verify SilkBomb image is executable
-        run: docker run --rm "${SILKBOMB_IMG}" --help
   compile:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -7,6 +7,28 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 jobs:
+  # TEMPORARY: validates ECR access for SilkBomb, remove before merge.
+  silkbomb-ecr-access:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
+      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
+    steps:
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
+      - name: Verify SilkBomb image is executable
+        run: docker run --rm "${SILKBOMB_IMG}" --help
   compile:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/generate-augmented-sbom.yml
+++ b/.github/workflows/generate-augmented-sbom.yml
@@ -16,12 +16,26 @@ jobs:
   augment-sbom:
     runs-on: ubuntu-latest
     env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
       KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
       KONDUKTO_REPO: ${{ vars.KONDUKTO_REPO }}
       KONDUKTO_BRANCH_PREFIX: ${{ vars.KONDUKTO_BRANCH_PREFIX }}
       SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
 
       - name: Get current date
         id: date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,11 @@ jobs:
     permissions:
       contents: write
       issues: write
+      id-token: write
+    env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
+      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -257,6 +262,16 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
         run: errout=$(mktemp); gh release create "$(cat dist/releasetag.txt)" -R "${GITHUB_REPOSITORY}" -F dist/changelog.md -t "$(cat dist/releasetag.txt)" --target "${GITHUB_REF}" 2> "$errout" && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" "$errout"; then cat "$errout"; exit $exitcode; fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
       - name: Generate PURL and SBOM
         run: |
           ./scripts/compliance/gen-purls.sh


### PR DESCRIPTION
## Summary
- The Artifactory-hosted SilkBomb registry is retired and `artifactory.corp.mongodb.com`'s TLS certificate expired, so `docker pull $SILKBOMB_IMG` fails. This broke the terraform-provider release ([example](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/31710003862/job/94486457829)); this repo has the same setup and would fail on its next release.
- Authenticate to the DevProd Platforms ECR registry via the shared read-only OIDC role before pulling SilkBomb, in `release.yml` (`release_github` job, which generates the SBOM) and `generate-augmented-sbom.yml`.
- Mirrors https://github.com/mongodb/atlas-sdk-go/pull/840 and https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4641.
- Repository variables `ECR_REGISTRY` and `ECR_ROLE_ARN` added, `SILKBOMB_IMG` repointed to the digest-pinned ECR image.

## Testing
- `actionlint` on all modified workflows.
- Temporary `silkbomb-ecr-access` job in `code-health.yml` verifies role assumption, ECR login, image pull and `silkbomb --help`. **Removed before merge.**